### PR TITLE
Use Maven flatten plugin to resolve ${revision} at deploy time; do not deploy parent pom

### DIFF
--- a/.github/actions/setup-polyglot-mvn-repo/action.yml
+++ b/.github/actions/setup-polyglot-mvn-repo/action.yml
@@ -3,7 +3,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup GraalVM Maven bundle - download
-      run: curl -L -o maven-resource-bundle.zip https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.27/maven-resource-bundle-25.0.0-ea.27.zip
+      run: curl -L -o maven-resource-bundle.zip https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.28/maven-resource-bundle-25.0.0-ea.28.zip
       shell: bash
 
     - name: Setup GraalVM Maven bundle - extract

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 TODO
 __pycache__
 *.swp
+.flattened-pom.xml

--- a/graalpy-archetype-polyglot-app/pom.xml
+++ b/graalpy-archetype-polyglot-app/pom.xml
@@ -41,7 +41,6 @@ SOFTWARE.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.graalvm.python</groupId>
     <artifactId>graalpy-extensions</artifactId>
@@ -52,7 +51,6 @@ SOFTWARE.
   <artifactId>graalpy-archetype-polyglot-app</artifactId>
   <description>Maven archetype providing a skeleton GraalPy - Java polyglot application.</description>
   <packaging>maven-archetype</packaging>
-
 
   <build>
     <extensions>

--- a/integration-tests/test_maven_plugin.py
+++ b/integration-tests/test_maven_plugin.py
@@ -53,7 +53,7 @@ VENV_UPTODATE = "Virtual environment is up to date with lock file, skipping inst
 
 class MavenPluginTest(util.BuildToolTestBase):
 
-    def generate_app(self, tmpdir, target_dir, target_name, pom_template=None, group_id="archetype.it", package="it.pkg"):
+    def generate_app(self, tmpdir, target_dir, target_name, pom_template=None, group_id="archetype.it", package="it.pkg", log=Logger()):
         cmd = util.GLOBAL_MVN_CMD + [
             "archetype:generate",
             "-B",
@@ -65,8 +65,8 @@ class MavenPluginTest(util.BuildToolTestBase):
             f"-Dpackage={package}",
             "-Dversion=0.1-SNAPSHOT",
         ]
-        out, return_code = util.run_cmd(cmd, self.env, cwd=str(tmpdir))
-        util.check_ouput("BUILD SUCCESS", out)
+        out, return_code = util.run_cmd(cmd, self.env, cwd=str(tmpdir), logger=log)
+        util.check_ouput("BUILD SUCCESS", out, logger=log)
 
         if pom_template:
             shutil.copyfile(pom_template, os.path.join(target_dir, "pom.xml"))
@@ -86,8 +86,9 @@ class MavenPluginTest(util.BuildToolTestBase):
             if use_default_vfs_path:
                 target_name += "_default_vfs_path"
 
+            log = Logger()
             target_dir = os.path.join(str(tmpdir), target_name)
-            self.generate_app(tmpdir, target_dir, target_name)
+            self.generate_app(tmpdir, target_dir, target_name, log=log)
 
             vfs_prefix = os.path.join('GRAALPY-VFS', 'archetype.it', target_name)
             graalpy_main_src = os.path.join(target_dir, "src", "main", "java", "it", "pkg", "GraalPy.java")
@@ -101,7 +102,6 @@ class MavenPluginTest(util.BuildToolTestBase):
                 vfs_prefix = util.DEFAULT_VFS_PREFIX
 
             mvnw_cmd = util.get_mvn_wrapper(target_dir, self.env)
-            log = Logger()
 
             # build
             cmd = mvnw_cmd + ["package", "-Pnative", "-DmainClass=it.pkg.GraalPy"]

--- a/javainterfacegen/pom.xml
+++ b/javainterfacegen/pom.xml
@@ -95,6 +95,26 @@ SOFTWARE.
     <build>
         <plugins>
             <plugin>
+                <!-- prevent deployment -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- prevent installation -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.4</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,8 @@
     <version>${revision}</version>
     <packaging>pom</packaging>
     <properties>
+        <!-- NOTE: revision is special and once can change it from cmd line: `mvn -Drevision=... package` -->
+        <!-- See https://maven.apache.org/guides/mini/guide-maven-ci-friendly.html -->
         <revision>25.0.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -16,6 +18,21 @@
         <!-- TODO: default test to run in GitHub CI for now -->
         <integration.tests.args>test_maven_plugin.MavenPluginTest.test_generated_app</integration.tests.args>
     </properties>
+
+    <developers>
+        <developer>
+            <name>GraalVM Development</name>
+            <email>graalvm-dev@oss.oracle.com</email>
+            <organization>Oracle Corporation</organization>
+            <organizationUrl>http://www.graalvm.org/</organizationUrl>
+        </developer>
+    </developers>
+    <licenses>
+        <license>
+            <name>Universal Permissive License, Version 1.0</name>
+            <url>http://opensource.org/licenses/UPL</url>
+        </license>
+    </licenses>
 
     <modules>
         <module>graalpy-archetype-polyglot-app</module>
@@ -71,9 +88,61 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <!-- "flattens" the pom.xml (inherited by submodules, so also theirs) before publishing to Maven repository. -->
+                <!-- Flattening resolves some placeholders, most importantly {revision} and removes the parent pom reference,
+                     so that we do not have to deploy the parent pom. -->
+                <!-- See https://maven.apache.org/guides/mini/guide-maven-ci-friendly.html -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.7.1</version>
+                <configuration>
+                    <flattenMode>ossrh</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- prevent deployment of the parent pom, intentionally not inherited by submodules -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- prevent installation of the parent pom, intentionally not inherited by submodules -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.4</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- Runs the integration tests through Maven passing some of the flags to the test driver automatically -->
+                <!-- The tests are run on GraalPy to avoid dependency on python3 installed on the system -->
+                <!-- One must run "mvn install" before running this goal -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.1.0</version>
+                <inherited>false</inherited>
                 <executions>
                     <execution>
                         <id>integration-tests</id>


### PR DESCRIPTION
This also fixes the integration tests that were broken by the `${revision}` change -- without the flatten plugin the `${revision}` is not resolved when uploading the pom.xml to Mavencentra/local repo and the Maven dependency resolution breaks on that when the artifact is used as a dependency.

The flatten plugin is actually useful also to remove stuff that we use only for development, so the final deployed pom.xml just contains relevant meta-data (description, dependencies, ...) and nothing else. When inspecting the deployed poms, I realized that we are missing license and developers meta-data -- also added in this PR.

Prevent javainterfacegen from deployment to Mavencentral/local repo for now.

Another issue in the integration tests: the 25.0.0 snapshots do not contain the Python 3.12 migration, so I made the `MultiContextCExtTest` work with both 3.11 and 3.12.