### PR TITLE
Run tests with both modulepath and classpath; Fix Gradle plugin test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,14 @@ jobs:
           - job_name: "unit"
             maven_args: "test"
             display: "All Unit Tests"
+          - job_name: "unit-modulepath"
+            maven_args: >-
+              -pl org.graalvm.python.embedding -Ptest.modules -am test
+            display: "Embedding Unit Tests Using Modulepath"
+          - job_name: "integration-modulepath"
+            maven_args: >-
+              -pl org.graalvm.python.embedding -Ptest.modules.integration -Dtest=org.graalvm.python.embedding.test.integration.** -am test
+            display: "Embedding Integration Unit Tests Using Modulepath"
           - job_name: "isolate-integration"
             maven_args: >-
               -pl org.graalvm.python.embedding -Pisolate -Dpolyglot.engine.AllowExperimentalOptions=true -Dpolyglot.engine.SpawnIsolate=true -Dpolyglot.engine.IsolateMode=external -Dtest=org.graalvm.python.embedding.test.integration.** -am test

--- a/org.graalvm.python.embedding/pom.xml
+++ b/org.graalvm.python.embedding/pom.xml
@@ -55,6 +55,41 @@
         </dependency>
       </dependencies>
     </profile>
+      <profile>
+          <!-- Runs the tests with module-path for those artifacts that are modules, other artifacts,
+          like 3rd party libs, that are not modules are still passed on class-path. -->
+          <id>test.modules</id>
+          <build>
+              <plugins>
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-surefire-plugin</artifactId>
+                      <configuration>
+                          <argLine>
+                              --add-opens org.graalvm.truffle/com.oracle.truffle.polyglot=org.graalvm.python.embedding
+                          </argLine>
+                          <useModulePath>true</useModulePath>
+                      </configuration>
+                  </plugin>
+              </plugins>
+          </build>
+      </profile>
+      <profile>
+          <!-- Like profile test.modules, but also doesn't add any 'add-opens' directives,
+          so this profile can run only integration subset of the unit tests -->
+          <id>test.modules.integration</id>
+          <build>
+              <plugins>
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-surefire-plugin</artifactId>
+                      <configuration>
+                          <useModulePath>true</useModulePath>
+                      </configuration>
+                  </plugin>
+              </plugins>
+          </build>
+      </profile>
   </profiles>
 
   <build>
@@ -63,9 +98,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <argLine>
-              --add-opens org.graalvm.truffle/com.oracle.truffle.polyglot=org.graalvm.python.embedding
-            </argLine>
+            <useModulePath>false</useModulePath>
           </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
* run embedding unit tests in classpath and modulepath mode
* in the end the failing Gradle plugin test was just a typo in the expected error message

- [ ] add module-info.java to the tests sources -- it turns out that's not simple. Maven doesn't expect that one would want something to be sometimes a module and other times not. I tried conditionally compiling module-info.java, but it probably confuses the compiler that then passes wrong flags to javac. I believe that our users will not use modules, so that's the primary configuration that we should test with - so no module-info.java in tests for now.