### PR TITLE
GraalPy Maven archetype takes version from parent pom ${revision}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,19 @@ jobs:
         os: [ubuntu-latest, macos-latest] # TODO: windows-latest
         test_name: [ test_jbang_integration.py, test_maven_plugin.py, test_gradle_plugin.py ]
         include:
-          # We need to skip native-image tests on MacOS runners, because they do not have enough
-          # RAM to reliably build a native image of GraalPy from Gradle (somehow Maven native-image
-          # tests seems to work, but we may need to disable them in the future too)
+          # We need to skip native-image tests on Gradle and MacOS runners: it seems that with
+          # Gradle the tests require more RAM and cannot reliably build native image.
+          # For other tests on MacOS we run just native-image smoke tests, because while building
+          # native-image seems to be feasible there, it is quite slow
           - test_name: test_gradle_plugin.py
             os: macos-latest
-            extra_test_args: "--skip-native-image"
+            extra_test_args: "--native-image=none"
+          - test_name: test_maven_plugin.py
+            os: macos-latest
+            extra_test_args: "--native-image=smoke"
+          - test_name: test_jbang_integration.py
+            os: macos-latest
+            extra_test_args: "--native-image=smoke"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,13 @@ jobs:
           mvn --batch-mode -s settings.xml -Dgradle.java.home=$GRADLE_JAVA_HOME exec:java@integration-tests -Dintegration.tests.args="${{ matrix.test_name }} ${{ matrix.extra_test_args }} $TEST_FLAGS"
         shell: bash
 
+      - name: Upload JBang native-image log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jbang-native-image-log
+          path: /tmp/jbang*native-image
+
   unit-tests:
     needs: [build, maven_bundle_url]
     runs-on: ${{ matrix.os }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,7 +18,7 @@ destination directory, and in the project root generates `settings.xml` that con
 Maven repository. The `settings.xml` file can be then passed to Maven using `-s settings.xml`.
 
 ```
-./scripts/setup-maven-bundle.sh ./maven-bundle
+./scripts/maven-bundle-setup.sh ./maven-bundle
 mvn -s ./settings.xml ...
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -90,5 +90,4 @@ verbosity level.
 
 ## Changing version
 
-- property `revision` in top level `pom.xml`
-- property `graalpy.version` in `graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/pom.xml` (TODO: propagate from revision)
+- just update property `revision` in top level `pom.xml`, everything else should be derived from it

--- a/graalpy-archetype-polyglot-app/pom.xml
+++ b/graalpy-archetype-polyglot-app/pom.xml
@@ -58,15 +58,42 @@ SOFTWARE.
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>3.2.1</version>
+        <version>3.4.0</version>
       </extension>
     </extensions>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>archetype-resources/pom.xml</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <excludes>
+          <exclude>archetype-resources/pom.xml</exclude>
+        </excludes>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <escapeString>\</escapeString>
+        </configuration>
+      </plugin>
+    </plugins>
 
     <pluginManagement>
       <plugins>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.4.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/pom.xml
+++ b/graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/pom.xml
@@ -3,15 +3,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>${groupId}</groupId>
-  <artifactId>${artifactId}</artifactId>
-  <version>${version}</version>
+  <groupId>\${groupId}</groupId>
+  <artifactId>\${artifactId}</artifactId>
+  <version>\${version}</version>
   <packaging>jar</packaging>
-  <name>${artifactId}</name>
+  <name>\${artifactId}</name>
 
-  #set( $symbol_dollar = '$' )
   <properties>
-    <graalpy.version>26.0.0-SNAPSHOT</graalpy.version>
+    <graalpy.version>${revision}</graalpy.version>
     <graalpy.edition>python-community</graalpy.edition>
     <native-maven-plugin.version>0.10.4</native-maven-plugin.version>
     <maven.compiler.target>17</maven.compiler.target>
@@ -19,6 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  #set( $symbol_dollar = '$' )
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
                                              "    Arguments are passed as `-Dintegration.tests.args='--no-clean --skip-long-running'`.\n"
                                              "    Maven passes --graalpy-version and --gradle-java-home automatically. Gradle Java home is taken from -Dgradle.java.home=...")
     parser.add_argument('--graalpy-version', help='The version of GraalPy and other Maven artifacts to use', required=True)
-    parser.add_argument('--skip-native-image', action='store_true', help='Skips tests that build projects with GraalVM Native Image (TODO: only recognized by gradle tests for now)')
+    parser.add_argument('--native-image', choices=['none', 'all', 'smoke'], default='all', help='Specifies which native image tests to run: "none" skips all, "all" runs all (default), "smoke" runs a basic subset. Use this instead of the deprecated --skip-native-image.')
     parser.add_argument('--skip-long-running', action='store_true', help='Skips long running tests')
     parser.add_argument('--no-clean', action='store_true', help='Do not clean the test temporary directories (for post-mortem debugging)')
     parser.add_argument('--jbang-graalpy-version', help='GraalPy version to use for JBang tests, overrides --graalpy-version')
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
     if 'JAVA_HOME' not in os.environ:
         print("WARNING: JAVA_HOME not in environment.\n")
-    elif not args.skip_native_image:
+    if args.native_image != 'none':
         suffix = '.exe' if sys.platform == 'win32' else ''
         if not os.path.exists(os.path.join(os.environ['JAVA_HOME'], 'bin', 'native-image' + suffix)):
             print("WARNING: JAVA_HOME is not a GraalVM distribution. Tests using Native Image will fail.\n")
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     util.graalvmVersion = args.graalpy_version
     util.long_running_test_disabled = args.skip_long_running
     util.no_clean = args.no_clean
-    util.test_native_image = not args.skip_native_image
+    util.native_image_mode = args.native_image
     util.jbang_graalpy_version = args.jbang_graalpy_version if args.jbang_graalpy_version else args.graalpy_version
     util.gradle_java_home = args.gradle_java_home
 

--- a/integration-tests/test_gradle_plugin.py
+++ b/integration-tests/test_gradle_plugin.py
@@ -154,7 +154,7 @@ class GradlePluginTestBase(util.BuildToolTestBase):
 
             gradlew_cmd = util.get_gradle_wrapper(target_dir, self.env)
 
-            if util.test_native_image:
+            if util.native_image_smoke():
                 cmd = gradlew_cmd + ["nativeCompile"]
                 out, return_code = util.run_cmd(cmd, self.env, cwd=target_dir, logger=log)
                 util.check_ouput("BUILD SUCCESS", out, logger=log)
@@ -323,7 +323,7 @@ class GradlePluginTestBase(util.BuildToolTestBase):
             out, return_code = util.run_cmd(cmd, self.env, cwd=target_dir)
             util.check_ouput("hello java", out)
 
-            if util.test_native_image:
+            if util.native_image_all():
                 # prepare for native build
                 meta_inf = os.path.join(target_dir, "src", "main", "resources", "META-INF", "native-image")
                 os.makedirs(meta_inf, exist_ok=True)
@@ -372,7 +372,7 @@ class GradlePluginTestBase(util.BuildToolTestBase):
             util.check_ouput("the python language home is always available", out, contains=True, logger=log)
 
     def check_gradle_check_home(self, community):
-        if not util.test_native_image:
+        if not util.native_image_all():
             raise unittest.SkipTest("native-image tests disabled")
 
         with TemporaryTestDirectory() as tmpdir:
@@ -567,7 +567,7 @@ class GradlePluginTestBase(util.BuildToolTestBase):
             util.check_ouput("1: hello java", out)
             assert return_code == 0, out
 
-            if util.test_native_image:
+            if util.native_image_all():
                 out, return_code = util.run_cmd(app2_gradle_cmd + ['nativeCompile'], self.env, cwd=app2_dir)
                 assert return_code == 0, out
 

--- a/integration-tests/test_jbang_integration.py
+++ b/integration-tests/test_jbang_integration.py
@@ -168,6 +168,9 @@ class TestJBangIntegration(unittest.TestCase):
 
     @unittest.skipUnless('win32' not in sys.platform, "Currently the jbang native image on Win gate fails.")
     def test_graalpy_template_native(self):
+        if not util.native_image_all():
+            self.skipTest("native-image tests disabled in smoke mode")
+
         template_name = "graalpy"
         test_file = "graalpy_test.java"
         work_dir = self.tmpdir
@@ -197,7 +200,7 @@ class TestJBangIntegration(unittest.TestCase):
         self.assertIn("Successfully installed termcolor", out)
         self.assertIn("hello java", out)
 
-        if not 'win32' in sys.platform:
+        if not 'win32' in sys.platform and util.native_image_smoke():
             command = JBANG_CMD + ["--native", hello_java_file, tested_code]
             out, result = run_cmd(command, cwd=work_dir)
 
@@ -274,7 +277,7 @@ def hello():
         self.assertNotIn("Successfully installed termcolor", out)
         self.assertIn("hello java", out)
 
-        if not 'win32' in sys.platform:
+        if not 'win32' in sys.platform and util.native_image_all():
             command = JBANG_CMD + ["--native", hello_java_file, tested_code]
             out, result = run_cmd(command, cwd=work_dir)
 

--- a/integration-tests/util.py
+++ b/integration-tests/util.py
@@ -57,7 +57,14 @@ graalvmVersion = None
 jbang_graalpy_version = None
 long_running_test_disabled = False
 no_clean = False
-test_native_image = True
+native_image_mode = "all"
+
+def native_image_all():
+    return native_image_mode == "all"
+
+def native_image_smoke():
+    return native_image_mode in ("all", "smoke")
+
 gradle_java_home = os.environ['JAVA_HOME']
 
 def long_running_test(func):


### PR DESCRIPTION
With this, there is only one source of truth for the project version: property revision in the top level pom.xml