### PR TITLE
Polish Maven metadata; support to build & test w/o access to the internet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  graalvm_version: '26-ea'
+  graalvm_version: '25'
 
 jobs:
   # This is done as one single separate step to work around rate limits for the API
@@ -28,7 +28,10 @@ jobs:
 
       - name: Set Maven Bundle URL
         id: set_url
-        run: echo "maven_bundle_url=$(./scripts/maven-bundle-url.sh | tail -n 1)" >> $GITHUB_OUTPUT
+        run: |
+          tmp_file="$(mktemp)"
+          ./scripts/maven-bundle-url.sh | tee "$tmp_file"
+          echo "maven_bundle_url=$(tail -n 1 "$tmp_file")" >> $GITHUB_OUTPUT
         shell: bash
 
   pre_commit:
@@ -184,11 +187,16 @@ jobs:
         if: runner.os == 'Windows'
         run: echo "C:\Program Files\Git\usr\bin" >> $env:GITHUB_PATH
 
+      # We scrape the output of integration tests for paths to interesting log files,
+      # so that we can then upload them in the following actions/upload-artifact
       - name: Run integration tests
+        id: tests_run
         run: |
           mvn --batch-mode -s settings.xml -Dgradle.java.home=$GRADLE_JAVA_HOME exec:java@integration-tests -Dintegration.tests.args="${{ matrix.test_name }} ${{ matrix.extra_test_args }} $TEST_FLAGS"
         shell: bash
 
+      # /var/folders/sw/**/T/jbang*native-image
+      # ^ not using this path on MacOS, because it causes
       - name: Upload JBang native-image log
         if: failure()
         uses: actions/upload-artifact@v4
@@ -196,7 +204,6 @@ jobs:
           name: jbang-native-image-log
           path: |
             /tmp/jbang*native-image
-            /var/folders/sw/**/T/jbang*native-image
 
   unit-tests:
     needs: [build, maven_bundle_url]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,14 +1,3 @@
-## Building for a Release
-
-* Verify that the following properties in `pom.xml` match the expected versions for the release:
-  * `revision`: the version for graalpy-extensions artifacts, e.g., `org.graalvm.python.embedding`
-  * `project.polyglot.version`: version of the polyglot artifacts to use, e.g., the version of `org.graalvm.polyglot:polyglot` dependency
-* The polyglot artifacts of given version must be available in Maven central or some additional
-  Maven repository that can be configured, for example, using Maven's setting.xml mechanism
-* Run Maven with `-P release` to sign the artifacts
-* Note: the files that are expected to be deployed include usual: `*.jar`, `*.asc`, `*.pom`,
-  and in case of `org.graalvm.python.embedding` also `*.sigfile`, which is used for API stability checking
-
 ## How to develop against the latest GraalPy, GraalVM SDK, and Truffle:
 
 ### Option 1: Use pre-built Maven bundle
@@ -20,6 +9,11 @@ Maven repository. The `settings.xml` file can be then passed to Maven using `-s 
 ```
 ./scripts/maven-bundle-setup.sh ./maven-bundle
 mvn -s ./settings.xml ...
+```
+
+Alternatively pass the local repo URL as property:
+```
+mvn -Dlocal.repo.url=file:///path/to/maven-bundle ...
 ```
 
 ### Option 2: Build and install GraalPy/Truffle from sources

--- a/graalpy-archetype-polyglot-app/pom.xml
+++ b/graalpy-archetype-polyglot-app/pom.xml
@@ -51,6 +51,12 @@ SOFTWARE.
   <name>graalpy-archetype-polyglot-app</name>
   <artifactId>graalpy-archetype-polyglot-app</artifactId>
   <description>Maven archetype providing a skeleton GraalPy - Java polyglot application.</description>
+  <url>${project.url.root}</url>
+  <scm>
+    <connection>${project.scm.connection}</connection>
+    <developerConnection>${project.scm.devConnection}</developerConnection>
+    <url>${project.scm.url}</url>
+  </scm>
   <packaging>maven-archetype</packaging>
 
   <build>
@@ -85,6 +91,16 @@ SOFTWARE.
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
           <escapeString>\</escapeString>
+        </configuration>
+      </plugin>
+      <!-- Effectively disables the maven-source-plugin inherited from parent pom. -->
+      <!-- The archetype-packaging extensions already contains maven-source-plugin
+           and the two of them would fight each other -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <attach>false</attach>
         </configuration>
       </plugin>
     </plugins>

--- a/graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/pom.xml
+++ b/graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,6 @@
 
   <properties>
     <graalpy.version>${revision}</graalpy.version>
-    <graalpy.edition>python-community</graalpy.edition>
     <native-maven-plugin.version>0.10.4</native-maven-plugin.version>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
@@ -28,7 +27,7 @@
     </dependency>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
-      <artifactId>${symbol_dollar}{graalpy.edition}</artifactId>
+      <artifactId>python</artifactId>
       <version>${symbol_dollar}{graalpy.version}</version>
       <type>pom</type>
     </dependency>

--- a/graalpy-maven-plugin/pom.xml
+++ b/graalpy-maven-plugin/pom.xml
@@ -51,6 +51,12 @@ SOFTWARE.
   <name>graalpy-maven-plugin</name>
   <artifactId>graalpy-maven-plugin</artifactId>
   <description>Handles python related resources in a maven GraalPy - Java polyglot application.</description>
+  <url>${project.url.root}</url>
+  <scm>
+    <connection>${project.scm.connection}</connection>
+    <developerConnection>${project.scm.devConnection}</developerConnection>
+    <url>${project.scm.url}</url>
+  </scm>
   <packaging>maven-plugin</packaging>
 
   <dependencies>

--- a/integration-tests/check_home_pom.xml
+++ b/integration-tests/check_home_pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
   <dependencies>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/check_packages_pom.xml
+++ b/integration-tests/check_packages_pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
   <dependencies>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/check_plugin_configuration.xml
+++ b/integration-tests/check_plugin_configuration.xml
@@ -53,7 +53,7 @@ SOFTWARE.
   <dependencies>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/gradle/gradle-test-project/gradle/wrapper/gradle-wrapper.properties
+++ b/integration-tests/gradle/gradle-test-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/integration-tests/merged_vfs_ujson_pom.xml
+++ b/integration-tests/merged_vfs_ujson_pom.xml
@@ -59,7 +59,7 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.graalvm.python</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/namespaced_venv.xml
+++ b/integration-tests/namespaced_venv.xml
@@ -59,7 +59,7 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.graalvm.python</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/namespaced_venv_user.xml
+++ b/integration-tests/namespaced_venv_user.xml
@@ -59,7 +59,7 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.graalvm.python</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/prepare_venv_old_ujson_pom.xml
+++ b/integration-tests/prepare_venv_old_ujson_pom.xml
@@ -59,7 +59,7 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.graalvm.python</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/prepare_venv_pom.xml
+++ b/integration-tests/prepare_venv_pom.xml
@@ -59,7 +59,7 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/prepare_venv_termcolor_pom.xml
+++ b/integration-tests/prepare_venv_termcolor_pom.xml
@@ -59,7 +59,7 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.graalvm.python</groupId>
-      <artifactId>python-community</artifactId>
+      <artifactId>python</artifactId>
       <version>${env.GRAALPY_VERSION}</version>
       <type>pom</type>
     </dependency>

--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -58,6 +58,9 @@ if __name__ == "__main__":
     parser.add_argument('--jbang-graalpy-version', help='GraalPy version to use for JBang tests, overrides --graalpy-version')
     parser.add_argument('--gradle-java-home', default=os.environ['JAVA_HOME'], help='Java to be used to run Gradle (by default $JAVA_HOME)')
     parser.add_argument('--help-unittest', action='store_true', help='Print help of the stdlib unittest CLI and exits')
+    parser.add_argument('--extra-maven-repos', default='', help='Semicolon separated list of additional Maven repositories. '
+                                                                'If GraalPy Maven archetype is not available in central, '
+                                                                'then it must be available in the first extra repository.')
     args, remaining_args = parser.parse_known_args()
 
     if args.help_unittest:
@@ -76,5 +79,6 @@ if __name__ == "__main__":
     util.native_image_mode = args.native_image
     util.jbang_graalpy_version = args.jbang_graalpy_version if args.jbang_graalpy_version else args.graalpy_version
     util.gradle_java_home = args.gradle_java_home
+    util.extra_maven_repos = args.extra_maven_repos.split(';') if args.extra_maven_repos else []
 
     unittest.main(argv=[sys.argv[0]] + remaining_args, module=None, exit=True)

--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -70,8 +70,9 @@ if __name__ == "__main__":
         print("WARNING: JAVA_HOME not in environment.\n")
     if args.native_image != 'none':
         suffix = '.exe' if sys.platform == 'win32' else ''
-        if not os.path.exists(os.path.join(os.environ['JAVA_HOME'], 'bin', 'native-image' + suffix)):
-            print("WARNING: JAVA_HOME is not a GraalVM distribution. Tests using Native Image will fail.\n")
+        ni_file = os.path.join(os.environ['JAVA_HOME'], 'bin', 'native-image' + suffix)
+        if not os.path.exists(ni_file):
+            print(f"WARNING: JAVA_HOME is not a GraalVM distribution. Tests using Native Image will fail. File does not exist: {ni_file}\n")
 
     util.graalvmVersion = args.graalpy_version
     util.long_running_test_disabled = args.skip_long_running

--- a/integration-tests/test_gradle_plugin.py
+++ b/integration-tests/test_gradle_plugin.py
@@ -77,6 +77,14 @@ class GradlePluginTestBase(util.BuildToolTestBase):
         util.replace_in_file(build_file, "$VERSION$", util.get_graalvm_version())
         settings_file = os.path.join(target_dir, self.settings_file_name)
         shutil.copyfile(os.path.join(os.path.dirname(__file__), "gradle", "scripts", self.settings_file_name), settings_file)
+        if util.extra_maven_repos:
+            mvn_repos = ""
+            for idx, custom_repo in enumerate(util.extra_maven_repos):
+                mvn_repos += f"maven {{ url \"{custom_repo}\" }}\n    "
+            util.replace_in_file(build_file,
+                                 "repositories {", f"repositories {{\n    mavenLocal()\n    {mvn_repos}")
+            util.replace_in_file(settings_file,
+                                 "repositories {", f"repositories {{\n        {mvn_repos}")
 
     def empty_plugin(self, community):
         pass

--- a/integration-tests/util.py
+++ b/integration-tests/util.py
@@ -49,7 +49,7 @@ from typing import Optional
 MAVEN_VERSION = "3.9.8"
 GLOBAL_MVN_CMD = [shutil.which('mvn'), "--batch-mode"]
 
-GRADLE_VERSION = "8.9"
+GRADLE_VERSION = "8.13"
 
 DEFAULT_VFS_PREFIX = "org.graalvm.python.vfs"
 

--- a/org.graalvm.python.embedding.tools/pom.xml
+++ b/org.graalvm.python.embedding.tools/pom.xml
@@ -15,6 +15,12 @@
     This artifact contains utilities for tools that want to integrate GraalPy
     packages into the build process of Java applications.
   </description>
+  <url>${project.url.root}</url>
+  <scm>
+    <connection>${project.scm.connection}</connection>
+    <developerConnection>${project.scm.devConnection}</developerConnection>
+    <url>${project.scm.url}</url>
+  </scm>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/org.graalvm.python.embedding/pom.xml
+++ b/org.graalvm.python.embedding/pom.xml
@@ -16,6 +16,12 @@
     Use this dependency if you install additional Python packages with the Maven
     or Gradle plugins for GraalPy.
   </description>
+  <url>${project.url.root}</url>
+  <scm>
+    <connection>${project.scm.connection}</connection>
+    <developerConnection>${project.scm.devConnection}</developerConnection>
+    <url>${project.scm.url}</url>
+  </scm>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/org.graalvm.python.embedding/pom.xml
+++ b/org.graalvm.python.embedding/pom.xml
@@ -75,6 +75,9 @@
                     <argument>-s</argument>
                     <argument>${session.request.userSettingsFile.path}</argument>
                     <argument>-Dlocal.repo.url=${local.repo.url}</argument>
+                    <argument>-Drevision=${revision}</argument>
+                    <argument>-Dproject.sigtest.version=${project.sigtest.version}</argument>
+                    <argument>-Dproject.polyglot.version=${project.polyglot.version}</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/org.graalvm.python.gradle.plugin/build.gradle
+++ b/org.graalvm.python.gradle.plugin/build.gradle
@@ -58,7 +58,7 @@ publishing {
         pom {
             name.set('GraalPy Plugin')
             description.set('Gradle plugin for GraalPy, a high-performance embeddable Python 3 runtime for Java. The plugin provides support for installing and managing Python packages.')
-            url.set('https://graalvm.org ')
+            url.set('https://graalvm.org/python')
             licenses {
                 license {
                     name.set('Universal Permissive License, Version 1.0')
@@ -68,8 +68,13 @@ publishing {
             developers {
                 developer {
                     name.set('GraalVM Development')
-                    email.set('graalvm-dev@oss.oracle.com ')
+                    email.set('graalvm-dev@oss.oracle.com')
                 }
+            }
+            scm {
+                connection.set('scm:git:git://github.com/oracle/graalpy-extensions.git')
+                developerConnection.set('scm:git:git://github.com/oracle/graalpy-extensions.git')
+                url.set('https://github.com/oracle/graalpy-extensions')
             }
         }
     }

--- a/org.graalvm.python.gradle.plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/org.graalvm.python.gradle.plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/org.graalvm.python.jbang/pom.xml
+++ b/org.graalvm.python.jbang/pom.xml
@@ -51,6 +51,12 @@ SOFTWARE.
   <name>graalpy-jbang-plugin</name>
   <artifactId>jbang</artifactId>
   <description>GraalPy JBang Integration.</description>
+  <url>${project.url.root}</url>
+  <scm>
+    <connection>${project.scm.connection}</connection>
+    <developerConnection>${project.scm.devConnection}</developerConnection>
+    <url>${project.scm.url}</url>
+  </scm>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,36 @@
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <id>mxurlrewrite</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>patch-gradle-props</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+                <configuration>
+                  <mainClass>com.oracle.graal.python.shell.GraalPythonMain</mainClass>
+                  <commandlineArgs>
+                    ${project.basedir}/scripts/gradle-patch-properties.py ${project.basedir}/org.graalvm.python.gradle.plugin/gradle/wrapper/gradle-wrapper.properties ${project.basedir}/integration-tests/gradle/gradle-test-project/gradle/wrapper/gradle-wrapper.properties
+                  </commandlineArgs>
+                  <!-- See the exec-maven-plugin configuration below in plugins section -->
+                  <includeProjectDependencies>true</includeProjectDependencies>
+                  <includePluginDependencies>true</includePluginDependencies>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,6 @@
   <groupId>org.graalvm.python</groupId>
   <artifactId>graalpy-extensions</artifactId>
   <version>${revision}</version>
-  <url>https://graalvm.org/python</url>
   <packaging>pom</packaging>
   <properties>
     <!-- NOTE: revision is special and one can change it from cmd line: `mvn -Drevision=... package` -->
@@ -14,9 +13,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.polyglot.version>${revision}</project.polyglot.version>
+    <project.url.root>https://graalvm.org/python</project.url.root>
+    <project.scm.connection>scm:git:git://github.com/oracle/graalpy-extensions.git</project.scm.connection>
+    <project.scm.devConnection>${project.scm.connection}</project.scm.devConnection>
+    <project.scm.url>https://github.com/oracle/graalpy-extensions</project.scm.url>
     <!-- JAVA_HOME to be used for Gradle plugin build and for Gradle integration tests -->
     <gradle.java.home>${java.home}</gradle.java.home>
-    <project.python.artifact>python-community</project.python.artifact>
+    <project.python.artifact>python</project.python.artifact>
     <project.junit.version>5.7.0</project.junit.version>
     <project.hamcrest.version>3.0</project.hamcrest.version>
     <project.sigtest.version>1.3</project.sigtest.version>
@@ -24,6 +27,9 @@
     <!-- intentionally empty: the default value, override with a URL the use a local repository -->
     <local.repo.url></local.repo.url>
   </properties>
+
+  <!-- submodules should override the generated URL to this exact value: -->
+  <url>${project.url.root}</url>
 
   <developers>
     <developer>
@@ -39,10 +45,11 @@
       <url>http://opensource.org/licenses/UPL</url>
     </license>
   </licenses>
+  <!-- submodules should override the generated URL: -->
   <scm>
-    <connection>scm:git:git://github.com/oracle/graalpy-extensions.git</connection>
-    <developerConnection>scm:git:git://github.com/oracle/graalpy-extensions.git</developerConnection>
-    <url>https://github.com/oracle/graalpy-extensions/tree/main</url>
+    <connection>${project.scm.connection}</connection>
+    <developerConnection>${project.scm.devConnection}</developerConnection>
+    <url>${project.scm.url}</url>
   </scm>
 
   <modules>
@@ -149,6 +156,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -271,6 +283,19 @@
         <configuration>
           <skip>true</skip>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <!-- prevent installation of the parent pom, intentionally not inherited by submodules -->

--- a/scripts/gradle-patch-properties.py
+++ b/scripts/gradle-patch-properties.py
@@ -1,0 +1,55 @@
+import sys
+import os
+import shutil
+import subprocess
+
+if len(sys.argv) < 2:
+    print("Usage: python gradle-patch-properties.py <path_to_gradle.properties> [<path2>, ...]")
+    print("Uses mx urlrewrites to patches distributionUrl in given Gradle properties file.")
+    print("If mx is not available or no urlrewrite rule applies, does nothing.")
+    sys.exit(1)
+
+for properties_path in sys.argv[1:]:
+    mx_exec = 'mx.cmd' if os.name == 'nt' else 'mx'
+    if shutil.which(mx_exec) is None:
+        print(f"mx executable not found, not rewriting distributionUrl in {properties_path}")
+        sys.exit(0)
+
+    try:
+        with open(properties_path, 'r') as f:
+            lines = f.readlines()
+    except IOError:
+        print(f"Error reading file: {properties_path}, not rewriting distributionUrl")
+        sys.exit(1)
+
+    found = False
+    updated = False
+    new_url = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith('distributionUrl='):
+            found = True
+            old_url = line.split('=', 1)[1].strip()
+            try:
+                new_url = subprocess.check_output([mx_exec, 'urlrewrite', old_url]).decode('utf-8').strip()
+                if new_url != old_url:
+                    lines[i] = f'distributionUrl={new_url}\n'
+                    updated = True
+                else:
+                    print(f"distributionUrl in {properties_path} is already set to {new_url}")
+            except subprocess.CalledProcessError as e:
+                print(f"Command `{mx_exec} urlrewrite {old_url}` failed: {e}")
+                sys.exit(1)
+            break
+
+    if updated:
+        try:
+            with open(properties_path, 'w') as f:
+                f.writelines(lines)
+            print(f"Patched distributionUrl in '{properties_path}' to '{new_url}'")
+            print("Do not commit this change")
+        except IOError:
+            print(f"Error writing file: {properties_path}, distributionUrl not updated according to mx urlrewrites")
+            sys.exit(1)
+    elif not found:
+        print(f"Did not find 'distributionUrl' in {properties_path}")
+        sys.exit(1)


### PR DESCRIPTION
* More polishing of Maven metadata for the release
* Get rid of `python-community` references
* Downgrade GraalVM from 26ea to 25 in GitHub actions
* In order to be able to build w/o internet access
    * Gradle build: support for rewriting the gradle wrapper URL if `mx urlrewrite` command is available
    * Integration tests: support passing extra Maven repositories
* Some more minor improvements