### PR TITLE
Use a ClassLoader for locating resources

### DIFF
--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystem.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystem.java
@@ -107,7 +107,7 @@ public final class VirtualFileSystem implements AutoCloseable {
 		private HostIO allowHostIO = HostIO.READ_WRITE;
 		private boolean caseInsensitive = VirtualFileSystemImpl.isWindows();
 
-        private ClassLoader resourceClassLoader;
+		private ClassLoader resourceClassLoader;
 
 		private String resourceDirectory;
 
@@ -244,7 +244,8 @@ public final class VirtualFileSystem implements AutoCloseable {
 		 * cases when for example <code>VirtualFileSystem</code> is on module path and
 		 * the jar containing the resources is on class path.
 		 *
-		 * @param c the class for loading the resources
+		 * @param c
+		 *            the class for loading the resources
 		 * @return the builder
 		 * @since 24.2.0
 		 */
@@ -253,21 +254,22 @@ public final class VirtualFileSystem implements AutoCloseable {
 			return this;
 		}
 
-        /**
-         * By default, virtual filesystem resources are loaded by delegating to
-         * <code>VirtualFileSystem.class.getClassLoader().getResource(name)</code>. Use
-         * <code>resourceClassLoader</code> to determine where to locate resources in
-         * cases when for example <code>VirtualFileSystem</code> is on module path and
-         * the jar containing the resources is on class path.
-         *
-         * @param cl the classloader used to load resources
-         * @return this builder
-         * @since 26.0.0
-         */
-        public Builder resourceClassLoader(ClassLoader cl) {
-            resourceClassLoader = cl;
-            return this;
-        }
+		/**
+		 * By default, virtual filesystem resources are loaded by delegating to
+		 * <code>VirtualFileSystem.class.getClassLoader().getResource(name)</code>. Use
+		 * <code>resourceClassLoader</code> to determine where to locate resources in
+		 * cases when for example <code>VirtualFileSystem</code> is on module path and
+		 * the jar containing the resources is on class path.
+		 *
+		 * @param cl
+		 *            the classloader used to load resources
+		 * @return this builder
+		 * @since 26.0.0
+		 */
+		public Builder resourceClassLoader(ClassLoader cl) {
+			resourceClassLoader = cl;
+			return this;
+		}
 
 		/**
 		 * This filter applied to files in the virtual filesystem treats them as
@@ -308,8 +310,8 @@ public final class VirtualFileSystem implements AutoCloseable {
 						? Path.of(DEFAULT_WINDOWS_MOUNT_POINT)
 						: Path.of(DEFAULT_UNIX_MOUNT_POINT);
 			}
-			return new VirtualFileSystem(extractFilter, mountPoint, allowHostIO, resourceClassLoader,
-					resourceDirectory, caseInsensitive);
+			return new VirtualFileSystem(extractFilter, mountPoint, allowHostIO, resourceClassLoader, resourceDirectory,
+					caseInsensitive);
 		}
 	}
 
@@ -327,7 +329,7 @@ public final class VirtualFileSystem implements AutoCloseable {
 			ClassLoader resourceClassLoader, String resourceDirectory, boolean caseInsensitive) {
 
 		this.impl = new VirtualFileSystemImpl(extractFilter, mountPoint, resourceDirectory, allowHostIO,
-				resourceClassLoader,  caseInsensitive);
+				resourceClassLoader, caseInsensitive);
 		this.delegatingFileSystem = VirtualFileSystemImpl.createDelegatingFileSystem(impl);
 	}
 

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystemImpl.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystemImpl.java
@@ -169,12 +169,12 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	 * Maps platform-specific paths to entries.
 	 */
 	private final Map<String, BaseEntry> vfsEntries = new HashMap<>();
-    
-    /**
-     * Classloader used to read resources. By defaut, the classloader of
-     * VirtualFileSystem.class.
-     */
-    private final ClassLoader resourceClassLoader;
+
+	/**
+	 * Classloader used to read resources. By defaut, the classloader of
+	 * VirtualFileSystem.class.
+	 */
+	private final ClassLoader resourceClassLoader;
 
 	static final String PLATFORM_SEPARATOR = Paths.get("").getFileSystem().getSeparator();
 	private static final char RESOURCE_SEPARATOR_CHAR = '/';
@@ -311,11 +311,11 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	 */
 	VirtualFileSystemImpl(Predicate<Path> extractFilter, Path mountPoint, String resourceDirectory, HostIO allowHostIO,
 			ClassLoader resourceClassLoader, boolean caseInsensitive) {
-        if (resourceClassLoader != null) {
-            this.resourceClassLoader = resourceClassLoader;
-        } else {
-            this.resourceClassLoader = VirtualFileSystem.class.getClassLoader();
-        }
+		if (resourceClassLoader != null) {
+			this.resourceClassLoader = resourceClassLoader;
+		} else {
+			this.resourceClassLoader = VirtualFileSystem.class.getClassLoader();
+		}
 		this.caseInsensitive = caseInsensitive;
 		this.mountPoint = mountPoint;
 		this.mountPointLowerCase = mountPoint.toString().toLowerCase(Locale.ROOT);
@@ -323,12 +323,14 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		this.platformVenvPath = resourcePathToPlatformPath(absoluteResourcePath(vfsRoot, VFS_VENV));
 		this.platformSrcPath = resourcePathToPlatformPath(absoluteResourcePath(vfsRoot, VFS_SRC));
 
-        if (LOGGER.isLoggable(Level.FINE)) {
-            var classLoaderLabel = this.resourceClassLoader == VirtualFileSystem.class.getClassLoader() ? "VirtualFileSystem" : "custom";
-            fine("VirtualFilesystem %s, allowHostIO: %s, resourceClassLoader: %s, caseInsensitive: %s, extractOnStartup: %s%s",
-                mountPoint, allowHostIO.toString(), classLoaderLabel, caseInsensitive,
-                extractOnStartup, extractFilter != null ? "" : ", extractFilter: null");
-        }
+		if (LOGGER.isLoggable(Level.FINE)) {
+			var classLoaderLabel = this.resourceClassLoader == VirtualFileSystem.class.getClassLoader()
+					? "VirtualFileSystem"
+					: "custom";
+			fine("VirtualFilesystem %s, allowHostIO: %s, resourceClassLoader: %s, caseInsensitive: %s, extractOnStartup: %s%s",
+					mountPoint, allowHostIO.toString(), classLoaderLabel, caseInsensitive, extractOnStartup,
+					extractFilter != null ? "" : ", extractFilter: null");
+		}
 		this.extractFilter = extractFilter;
 		if (extractFilter != null) {
 			try {
@@ -747,8 +749,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		// by the Maven/Gradle plugin and should contain "pip freeze" of the venv
 		ArrayList<URL> installedUrls;
 		try {
-			installedUrls = Collections.list(
-                resourceClassLoader.getResources(resourcePath(vfsRoot, INSTALLED_FILE)));
+			installedUrls = Collections.list(resourceClassLoader.getResources(resourcePath(vfsRoot, INSTALLED_FILE)));
 		} catch (IOException e) {
 			warn("Cannot check compatibility of the merged virtual environments. Cannot read list of packages installed in the virtual environments. IOException: "
 					+ e.getMessage());
@@ -792,8 +793,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		// Check compatibility of GraalPy versions that were used to create the VFSs
 		ArrayList<URL> contentsUrls;
 		try {
-			contentsUrls = Collections.list(
-					resourceClassLoader.getResources(resourcePath(vfsRoot, CONTENTS_FILE)));
+			contentsUrls = Collections.list(resourceClassLoader.getResources(resourcePath(vfsRoot, CONTENTS_FILE)));
 		} catch (IOException e) {
 			warn("Cannot check compatibility of the merged virtual environments. Cannot read GraalPy version of the virtual environments. IOException: "
 					+ e.getMessage());


### PR DESCRIPTION
# Description

Before this change, the VirtualFileSystem was using a `Class` as a beacon to find resources. I suppose that the intent was to use `Class#getResource`, but in practice, it's always `clazz.getClassLoader().getResource()` which is used, which makes it redundant to use a class. This commit refactors the code to allow declaring which _classloader_ to use for loading. This is important because in some cases, we don't necessarily have a `Class` to pass, but we _do_ have a classloader. This should also allow more advanced scenarios with filtering classloaders for example.

Since the `Class` was actually never directly used, but only its classloader, this change should have 0 impact for backwards compatibility.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] org.graalvm.python.embedding.test.VirtualFileSystemTest
- [x] org.graalvm.python.embedding.test.integration.VirtualFileSystemIntegrationTest 

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
