### PR TITLE
Deprecate python-community artifact

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,7 +68,8 @@ mvn -pl org.graalvm.python.gradle.plugin -am clean
 tl;dr:
 
 ```
-mvn install exec:java@integration-tests -Dintegration.test.args="test_maven_plugin.py" -Dgradle.java.home=...
+mvn install exec:java@integration-tests # to view the help
+mvn install exec:java@integration-tests -Dintegration.tests.args="test_maven_plugin.py" -Dgradle.java.home=...
 ```
 
 The integration tests are driven by Python and implemented using unittest framework, which is
@@ -78,7 +79,7 @@ published in Mavencentral or some snapshot repository configured in Maven settin
 
 The whole execution of the tests is wrapped in Maven goal `exec:java@integration-tests`, which passes
 some necessary arguments to the test driver Python script. One can pass additional arguments for the
-unittest framework using system property `integration.test.args`, for example, tests to execute or
+unittest framework using system property `integration.tests.args`, for example, tests to execute or
 verbosity level.
 
 

--- a/org.graalvm.python.gradle.plugin/src/main/java/org/graalvm/python/GraalPyGradlePlugin.java
+++ b/org.graalvm.python.gradle.plugin/src/main/java/org/graalvm/python/GraalPyGradlePlugin.java
@@ -136,6 +136,11 @@ public abstract class GraalPyGradlePlugin implements Plugin<Project> {
 		warnOnUserDeclaredConflicts(project, extension);
 
 		project.afterEvaluate(proj -> {
+			if (extension.getCommunity().convention(false).get()) {
+				proj.getLogger().warn(
+						"WARNING: 'python-community' is deprecated. The plugin defaults to 'python'. Support for 'python-community' may be removed in a future release.");
+			}
+
 			if (extension.getPythonResourcesDirectory().isPresent() && extension.getExternalDirectory().isPresent()) {
 				throw new GradleException(
 						"Cannot set both 'externalDirectory' and 'resourceDirectory' at the same time. "
@@ -335,10 +340,13 @@ public abstract class GraalPyGradlePlugin implements Plugin<Project> {
 					}
 					if (hasCommunityEdition && hasOracleEdition) {
 						throw new GradleException(
-								"You have both 'org.graalvm.python:python' and 'org.graalvm.python:python-community' on the classpath. "
-										+ "This is likely due to an explicit dependency added, or duplicate dependencies. You may configure "
-										+ "the GraalPy plugin to inject the 'python-community' artifact by using the graalPy { community = true } "
+								"You have both 'org.graalvm.python:python' (or 'org.graalvm.polyglot:python') and 'org.graalvm.python:python-community' (or 'org.graalvm.polyglot:python-community') on the classpath. "
+										+ "The 'python-community' artifact is deprecated. Ensure only one edition is present. You may configure "
+										+ "the GraalPy plugin to inject the deprecated 'python-community' artifact by using the graalPy { community = true } "
 										+ "configuration block instead.");
+					} else if (hasCommunityEdition && !hasOracleEdition) {
+						org.gradle.api.logging.Logging.getLogger(GraalPyGradlePlugin.class).warn(
+								"WARNING: 'python-community' is deprecated. Please depend on 'org.graalvm.python:python' or 'org.graalvm.polyglot:python' instead.");
 					}
 				});
 	}


### PR DESCRIPTION
~~Depends on https://github.com/oracle/graalpy-extensions/pull/31~~

Requires version update to 25.1.0 and to use 25.1.0 EA polyglot maven bundle as fixed in https://github.com/oracle/graalpy-extensions/pull/31 -- update: merged as part of another PR