### PR TITLE
Prepare the javainterfacegenerator project for agents

### DIFF
--- a/javainterfacegen/AGENTS.md
+++ b/javainterfacegen/AGENTS.md
@@ -1,0 +1,1 @@
+README.md

--- a/javainterfacegen/README.md
+++ b/javainterfacegen/README.md
@@ -1,32 +1,184 @@
-This tool generates Java interfaces from Python files. It relies on the Pyhton
-Mypy package, which parses Python source code and provides an attributed AST
-with type information.
+# Java Interface Generator
 
-Currently, running Mypy on GraalVM is slow, so the program uses cached results
-generated after the first run. These caches should not be added to version
-control (git) because they contain absolute file paths.
+A tool that generates Java interfaces from Python source code, enabling seamless interoperability between Java and Python through [GraalPy](https://www.graalvm.org/python/).
 
-Although it's a Maven project, a binary launcher named `javainterfacegen` is
-generated in the `bin` folder during the build process. You can build it
-as part of the GraalPython project by running
-```bash
-mx build
-```
-from the top-level graalpython repository folder. The `javainterfacegen`
- executable will be located in `graal/sdk/latest_graalvm_home/bin/`.
+## Overview
 
-Alternatively, you can build it directly in this repository using Maven with
-the following command:
+The Java Interface Generator analyzes Python code using [MyPy](http://mypy-lang.org/) and produces idiomatic Java interfaces that wrap Python classes, functions, and modules. This allows Java developers to interact with Python libraries using familiar Java patterns while maintaining type safety.
+
+## Documentation
+
+- [Configuration Quick Start](doc/configuration-quickstart.md) - Get started with YAML configuration
+- [Configuration Reference](doc/configuration-reference.md) - Complete configuration options
+- [Usage Examples](doc/usage-examples.md) - Detailed examples with Python and Java code
+- [Architecture Overview](doc/architecture.md) - System design and component descriptions
+- [MyPy Integration](doc/mypy-integration.md) - How MyPy is used for type extraction
+- [Python to Java Type Translation](doc/python-to-java-type-translation.md) - Type mapping rules
+
+## Quick Start
+
+### 1. Build the Tool
+
 ```bash
 mvn package -DskipTests
 ```
 
-To run the program using Maven, you can use a command like this:
+If Maven fails with `Could not find artifact org.graalvm.python:graalpy-maven-plugin:...-SNAPSHOT`,
+build/install the plugin first from the parent `graalpy-extensions` project root:
+
 ```bash
-mvn exec:java -Dexec.mainClass="org.graalvm.python.javainterfacegen.Main" -Dexec.args="./examples/pygal/pygal.yml"
+mvn -pl graalpy-maven-plugin -am install -DskipTests
+mvn -pl javainterfacegen -am package -DskipTests
 ```
 
-For debugging, you need to increase the stack size:
-```bash
-MAVEN_OPTS="-Xss64M" mvnDebug exec:java -Dexec.mainClass="org.graalvm.python.javainterfacegen.Main" -Dexec.args="./examples/pygal/pygal.yml"
+### 2. Create a Configuration File
+
+Create a YAML configuration file (e.g., `myproject.yml`):
+
+```yaml
+# Input Python files or directories
+files:
+  - path: ./mypackage
+
+# Output configuration
+target_folder: ./generated-sources
+interface_package: com.example.mypackage
+
+# Cache directories (speeds up subsequent runs)
+generator_cache_folder: ./cache/generator
 ```
+
+### 3. Run the Generator
+
+```bash
+# Standard invocation (available in all builds)
+mvn exec:java \
+  -Dexec.mainClass="org.graalvm.python.javainterfacegen.Main" \
+  -Dexec.args="./myproject.yml"
+
+# Optional executable (only if you have built/installed a launcher for your environment)
+# javainterfacegen ./myproject.yml
+```
+
+Use the Maven command as the default documented path. The `javainterfacegen` executable is environment/build dependent and may not be produced in a standard local Maven flow.
+
+## Example
+
+**Python source (`calculator.py`):**
+```python
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+```
+
+**Configuration (`calculator.yml`):**
+```yaml
+files:
+  - path: ./calculator.py
+target_folder: ./generated
+interface_package: com.example.calculator
+generator_cache_folder: ./cache/generator
+```
+
+**Generated Java interface:**
+```java
+package com.example.calculator;
+
+public interface Calculator {
+    long add(long a, long b);
+
+    static Calculator fromContext(Context context) { ... }
+}
+```
+
+**Using the generated interface:**
+```java
+try (Context context = Context.newBuilder("python").build()) {
+    Calculator calc = Calculator.fromContext(context);
+    long sum = calc.add(5, 3);  // Returns 8
+}
+```
+
+For more examples including class generation, type factories, and advanced configurations, see [Usage Examples](doc/usage-examples.md).
+
+## Configuration Reference
+
+For complete configuration documentation, see:
+- [Configuration Quick Start](doc/configuration-quickstart.md) - Common configuration patterns
+- [Configuration Reference](doc/configuration-reference.md) - All options with defaults
+
+### Key Settings
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `files` | *(required)* | Python files or directories to process |
+| `target_folder` | *(required)* | Output directory for generated Java code |
+| `interface_package` | `org.mycompany.api` | Java package for interfaces |
+| `generator_cache_folder` | *(must be set explicitly)* | Cache folder currently used for MyPy cache path and serialized AST cache |
+| `generate_type_interface` | `false` | Generate `*Type` factory interfaces |
+| `whitelist` | *(none)* | Only generate listed classes/functions |
+| `ignore` | *(none)* | Exclude listed names |
+| `type_mappings` | *(none)* | Custom Python-to-Java type mappings |
+
+## Debugging
+
+### Increase Stack Size
+
+For large Python codebases with deep class hierarchies:
+
+```bash
+MAVEN_OPTS="-Xss64M" mvn exec:java \
+  -Dexec.mainClass="org.graalvm.python.javainterfacegen.Main" \
+  -Dexec.args="./myproject.yml"
+```
+
+### Enable Debug Comments
+
+```yaml
+generate_log_comments: true
+```
+
+This adds comments showing:
+- Python type information
+- Why certain code paths were chosen
+- Unresolved type placeholders
+
+### Debug with Maven
+
+```bash
+MAVEN_OPTS="-Xss64M" mvnDebug exec:java \
+  -Dexec.mainClass="org.graalvm.python.javainterfacegen.Main" \
+  -Dexec.args="./myproject.yml"
+```
+
+Then attach a debugger to port 8000.
+
+## Building from Source
+
+### Prerequisites
+
+- JDK 21 or later
+- Maven 3.6+
+- GraalPy (or run within GraalVM)
+
+### Build Commands
+
+```bash
+# Compile
+mvn compile
+
+# Run tests
+mvn test
+
+# Package (skip tests for faster build)
+mvn package -DskipTests
+
+# Run directly
+mvn exec:java \
+  -Dexec.mainClass="org.graalvm.python.javainterfacegen.Main" \
+  -Dexec.args="./path/to/config.yml"
+```
+
+## License
+
+Universal Permissive License (UPL), Version 1.0

--- a/javainterfacegen/doc/architecture.md
+++ b/javainterfacegen/doc/architecture.md
@@ -1,0 +1,284 @@
+# Java Interface Generator Architecture
+
+This document describes the architecture and design of the Java Interface Generator tool.
+
+## Overview
+
+The Java Interface Generator automatically creates Java interfaces from Python source code, enabling Java applications to interoperate with Python libraries through GraalPy. The tool leverages MyPy's type system to extract accurate type information and generates idiomatic Java interfaces.
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Python Source  │────▶│  MyPy Analysis  │────▶│  Java Interface │
+│   (.py/.pyi)    │     │   (Type AST)    │     │   Generation    │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+        │                       │                       │
+        ▼                       ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  YAML Config    │     │  Cached JSON    │     │  .java Files    │
+│  (input spec)   │     │  (parsed AST)   │     │  (output)       │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+```
+
+## Core Components
+
+### 1. Entry Point
+
+[`Main`](../src/main/java/org/graalvm/python/javainterfacegen/Main.java) orchestrates the generation pipeline:
+
+1. Loads YAML configuration
+2. Resolves input Python file paths
+3. Invokes MyPy parsing (or loads from cache)
+4. Generates Javadoc from docstrings
+5. Generates Java interfaces via [`TransformerVisitor`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TransformerVisitor.java)
+6. Handles unresolved types
+7. Exports type mappings and native-image proxy configuration
+
+### 2. Configuration System
+
+The configuration system ([`Configuration`](../src/main/java/org/graalvm/python/javainterfacegen/configuration/Configuration.java)) provides:
+
+- **YAML-based configuration** via [`YamlConfigurationLoader`](../src/main/java/org/graalvm/python/javainterfacegen/configuration/YamlConfigurationLoader.java)
+- **Hierarchical property resolution** (global → file → class → function)
+- **Customizable generators** for functions, types, Javadoc, and naming
+
+Key configuration properties:
+
+| Property | Description |
+|----------|-------------|
+| `files` | Python files/directories to process |
+| `target_folder` | Output directory for generated Java code |
+| `interface_package` | Java package for generated interfaces |
+| `type_mappings` | Custom Python→Java type mappings |
+| `whitelist` | Explicit list of classes/functions to include |
+| `ignore` | Classes/functions to exclude |
+
+See [`DefaultConfigurationLoader`](../src/main/java/org/graalvm/python/javainterfacegen/configuration/DefaultConfigurationLoader.java) for all defaults.
+
+### 3. MyPy Integration
+
+[`MypyHook`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/MypyHook.java) bridges Java and Python MyPy:
+
+- Invokes MyPy through GraalPy's polyglot interface
+- Serializes/deserializes parsed AST to JSON cache
+- Extracts docstrings from Python source
+
+The Python-side implementation lives in [`analyzePath.py`](../src/main/resources/GRAALPY-VFS/org.graalvm.python/javainterfacegen/src/analyzePath.py).
+
+See [MyPy Integration](./mypy-integration.md) for detailed documentation.
+
+### 4. AST Node Wrappers
+
+The `mypy.nodes` package provides Java wrappers for MyPy's AST nodes:
+
+| Node Type | Java Interface | Description |
+|-----------|----------------|-------------|
+| `MypyFile` | [`MypyFile`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/MypyFile.java) | Python module |
+| `ClassDef` | [`ClassDef`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/ClassDef.java) | Class definition |
+| `FuncDef` | [`FuncDef`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/FuncDef.java) | Function/method definition |
+| `Var` | [`Var`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/Var.java) | Variable/attribute |
+| `TypeInfo` | [`TypeInfo`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/TypeInfo.java) | Class metadata (bases, MRO, etc.) |
+
+### 5. Type System Wrappers
+
+The `mypy.types` package wraps MyPy's type representations:
+
+| Type | Java Interface | Description |
+|------|----------------|-------------|
+| `Instance` | [`Instance`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/Instance.java) | Class instance type |
+| `UnionType` | [`UnionType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/UnionType.java) | Union of types |
+| `CallableType` | [`CallableType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/CallableType.java) | Function signature |
+| `TupleType` | [`TupleType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/TupleType.java) | Tuple type |
+| `TypeVarType` | [`TypeVarType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/TypeVarType.java) | Type variable |
+
+### 6. Code Generation
+
+#### TransformerVisitor
+
+[`TransformerVisitor`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TransformerVisitor.java) implements the visitor pattern to traverse MyPy's AST and generate Java code:
+
+```
+MypyFile.visit() ──▶ Generate module interface
+    │
+    ├── ClassDef.visit() ──▶ Generate class interface
+    │       │
+    │       ├── FuncDef.visit() ──▶ Generate method signature
+    │       └── Var.visit() ──▶ Generate getter/setter
+    │
+    └── FuncDef.visit() ──▶ Generate module-level function
+```
+
+#### GeneratorContext
+
+[`GeneratorContext`](../src/main/java/org/graalvm/python/javainterfacegen/generator/GeneratorContext.java) maintains generation state:
+
+- Current AST node being processed
+- Import tracking
+- Indentation level
+- Java FQN of generated class
+- Configuration property resolution
+
+#### TypeManager
+
+[`TypeManager`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java) handles Python→Java type translation:
+
+- Maintains registered type mappings
+- Resolves MyPy types to Java types
+- Tracks unresolved types for later patching
+- Supports primitive boxing for generics
+
+See [Python to Java Type Translation](./python-to-java-type-translation.md) for detailed rules.
+
+### 7. Generator Plugins
+
+The tool uses a plugin architecture for customizable generation:
+
+| Interface | Purpose | Default Implementation |
+|-----------|---------|------------------------|
+| [`FunctionGenerator`](../src/main/java/org/graalvm/python/javainterfacegen/generator/FunctionGenerator.java) | Method signature generation | [`JustInterfacesGeneratorImpl`](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/JustInterfacesGeneratorImpl.java) |
+| [`TypeGenerator`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeGenerator.java) | Complex type generation | [`TypeInterfaceGeneratorImpl`](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/TypeInterfaceGeneratorImpl.java) |
+| [`NameGenerator`](../src/main/java/org/graalvm/python/javainterfacegen/generator/NameGenerator.java) | Java naming conventions | [`NameGeneratorImpl`](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/NameGeneratorImpl.java) |
+| [`JavadocGenerator`](../src/main/java/org/graalvm/python/javainterfacegen/generator/JavadocGenerator.java) | Javadoc from docstrings | [`JavadocGeneratorImpl`](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/JavadocGeneratorImpl.java) |
+
+Plugins are discovered via Java ServiceLoader from `META-INF/services/`.
+
+## Data Flow
+
+### 1. Parsing Phase
+
+```
+Python files ──▶ MyPy ──▶ Typed AST ──▶ JSON cache
+                  │
+                  └── Type checking and inference
+```
+
+### 2. Generation Phase
+
+```
+JSON cache ──▶ MypyFile objects ──▶ TransformerVisitor
+                                          │
+                    ┌─────────────────────┼─────────────────────┐
+                    ▼                     ▼                     ▼
+              Interface.java      InterfaceType.java    type-classes/
+              (instance API)      (static API/factory)  (complex types)
+```
+
+### 3. Post-Processing Phase
+
+```
+Generated .java files ──▶ TypeManager.handleUnresolved()
+                                │
+                                ├── Replace type placeholders
+                                ├── Add TODO comments for unknown types
+                                └── Export type mappings
+```
+
+## Generated Code Structure
+
+For a Python class `mymodule.MyClass`:
+
+```java
+// MyClass.java - Instance interface
+public interface MyClass extends GuestValue {
+    // Instance methods
+    String getName();
+    void setName(String value);
+
+    // Type checking
+    static boolean isInstance(Object object) { ... }
+    static MyClass cast(Object o) { ... }
+}
+
+// MyClassType.java - Static/factory interface (optional)
+public interface MyClassType {
+    // Factory method
+    static MyClassType getPythonType(Context context) { ... }
+
+    // Constructor wrapper
+    default MyClass newInstance(String name) { ... }
+
+    // Static methods and class attributes
+    static Value CLASS_CONSTANT = ...;
+}
+```
+
+## Caching and Performance
+
+### Why Caching Matters
+
+Running MyPy on GraalVM is slower than on standard CPython. The tool caches parsed results to speed up subsequent runs.
+
+Current runtime behavior uses one configured cache folder:
+
+1. **Generator cache** (`generator_cache_folder`): Serialized AST as JSON, and also the folder passed to MyPy as its cache directory
+
+Cache behavior:
+- **First run**: Full MyPy analysis (may take minutes for large codebases)
+- **Subsequent runs**: Load from cache / deserialize JSON (seconds)
+
+### Cache Management
+
+Caches contain absolute file paths and should **not** be committed to version control.
+
+Example `.gitignore` entries:
+
+```gitignore
+# .gitignore
+generator_cache/
+*.json  # If storing cache as JSON
+```
+
+Regenerate caches when:
+- Python source files change
+- Files are moved or renamed
+- Working directory changes
+## Extension Points
+
+### Custom Type Mappings
+
+```yaml
+type_mappings:
+  mymodule.CustomType: com.example.JavaCustomType
+  numpy.ndarray: org.graalvm.polyglot.Value
+```
+
+### Custom Generators
+
+Implement the generator interface and register in `META-INF/services/`:
+
+```java
+public class CustomFunctionGenerator implements FunctionGenerator {
+    @Override
+    public String createSignature(FuncDef funcDef, GeneratorContext context) {
+        // Custom signature generation
+    }
+}
+```
+
+### Whitelist/Blacklist
+
+```yaml
+whitelist:
+  - class: mymodule.ImportantClass
+  - function: mymodule.important_function
+
+ignore:
+  - internal_helper
+  - _private_class
+```
+
+## Error Handling
+
+- **Unresolved types**: Placeholder markers in generated code, patched post-generation
+- **Missing docstrings**: TODO comments or empty Javadoc
+- **Invalid Python**: Propagated MyPy errors
+
+## Performance Considerations
+
+1. **Initial parse**: MyPy on GraalVM is slow; use caching
+2. **Large codebases**: Process incrementally by module
+3. **Memory**: Increase stack size for deep AST traversal (`-Xss64M`)
+
+## Related Documentation
+
+- [Python to Java Type Translation](./python-to-java-type-translation.md)
+- [MyPy Integration](./mypy-integration.md)

--- a/javainterfacegen/doc/configuration-quickstart.md
+++ b/javainterfacegen/doc/configuration-quickstart.md
@@ -1,0 +1,146 @@
+# Configuration Quick Start
+
+This guide gets you started with YAML configuration files for the Java Interface Generator.
+
+## Minimal Configuration
+
+Create a file named `myproject.yml`:
+
+```yaml
+files:
+  - path: ./src/python
+
+target_folder: ./generated-sources
+interface_package: com.example.myapi
+generator_cache_folder: ./cache/generator
+```
+
+Run the generator (default path via Maven):
+
+```bash
+mvn exec:java \
+  -Dexec.mainClass="org.graalvm.python.javainterfacegen.Main" \
+  -Dexec.args="./myproject.yml"
+```
+
+Optional launcher (environment/build dependent, not always produced in a standard Maven flow):
+
+```bash
+javainterfacegen ./myproject.yml
+```
+
+That's it! The generator will analyze all Python files in `./src/python` and output Java interfaces to `./generated-sources`.
+
+## Common Configurations
+
+### Single Python File
+
+```yaml
+files:
+  - path: ./calculator.py
+
+target_folder: ./generated
+interface_package: com.example.calculator
+generator_cache_folder: ./cache/generator
+```
+
+### Multiple Files and Directories
+
+```yaml
+files:
+  - path: ./core.py
+  - path: ./utils/
+  - path: ./models/
+
+target_folder: ./generated
+interface_package: com.example
+generator_cache_folder: ./cache/generator
+```
+
+### With Caching (Recommended for Large Projects)
+
+Caching dramatically speeds up subsequent runs:
+
+```yaml
+files:
+  - path: ./mypackage
+
+target_folder: ./generated
+interface_package: com.example.mypackage
+
+# Cache directories
+generator_cache_folder: ./cache/generator
+```
+
+### Generate Type Factory Interfaces
+
+Enable `*Type` interfaces for creating Python objects from Java:
+
+```yaml
+files:
+  - path: ./shapes.py
+
+target_folder: ./generated
+interface_package: com.example.shapes
+generator_cache_folder: ./cache/generator
+generate_type_interface: true
+```
+
+This generates both `Rectangle` (instance interface) and `RectangleType` (factory interface).
+
+### Filter What Gets Generated
+
+Include only specific classes or functions:
+
+```yaml
+files:
+  - path: ./large_module.py
+
+target_folder: ./generated
+interface_package: com.example.api
+generator_cache_folder: ./cache/generator
+
+whitelist:
+  - class: PublicAPI
+  - class: DataModel
+  - function: process_data
+```
+
+Or exclude internal items:
+
+```yaml
+files:
+  - path: ./module.py
+
+target_folder: ./generated
+interface_package: com.example
+generator_cache_folder: ./cache/generator
+
+ignore:
+  - _internal_helper
+  - DebugClass
+  - test_function
+```
+
+### Custom Type Mappings
+
+Map Python types to specific Java types:
+
+```yaml
+files:
+  - path: ./data_module.py
+
+target_folder: ./generated
+interface_package: com.example.data
+generator_cache_folder: ./cache/generator
+
+type_mappings:
+  numpy.ndarray: org.graalvm.polyglot.Value
+  pandas.DataFrame: com.example.DataFrameWrapper
+```
+
+## Next Steps
+
+- See [Configuration Reference](configuration-reference.md) for all available options
+- See [Python to Java Type Translation](python-to-java-type-translation.md) for type mapping details
+- See [Architecture Overview](architecture.md) for how the generator works

--- a/javainterfacegen/doc/configuration-reference.md
+++ b/javainterfacegen/doc/configuration-reference.md
@@ -1,0 +1,636 @@
+# Configuration Reference
+
+Complete reference for all YAML configuration options in the Java Interface Generator.
+
+## Configuration File Structure
+
+Configuration files use YAML format. The generator merges user-provided values with defaults, but current runtime behavior requires a few key properties to be set explicitly.
+
+```yaml
+# Required for current runtime
+files:
+  - path: ./module.py
+generator_cache_folder: ./cache/generator
+
+# Commonly set
+target_folder: ./output
+interface_package: com.example.api
+```
+
+Unless stated otherwise, property snippets below are partial examples and may omit other required settings.
+
+---
+
+## Required Properties
+
+### `files`
+
+**Type:** String, or list of file configurations
+**Required:** Yes
+
+Python files or directories to process.
+
+**List of paths (current runtime-compatible list form):**
+```yaml
+files:
+  - path: ./module.py
+  - path: ./package/ # includes all python files from the dir
+```
+
+**Single file:**
+```yaml
+files: ./single_module.py
+```
+
+**File-specific configuration:**
+```yaml
+files:
+  - path: ./core.py
+    interface_package: com.example.core
+
+  - path: ./utils.py
+    interface_package: com.example.utils
+    ignore:
+      - debug_function
+```
+
+### `target_folder`
+
+**Type:** String (path)
+**Required:** Yes
+**Default:** `./target/generated-sources/src`
+
+Output directory for generated Java source files. Relative paths are resolved from the configuration file's location.
+
+```yaml
+target_folder: ./generated-sources
+```
+
+### `generator_cache_folder`
+
+**Type:** String (path)
+**Required for current runtime:** Yes
+
+Cache directory currently used for both serialized AST cache and the MyPy cache path passed to the runtime hook.
+
+```yaml
+generator_cache_folder: ./cache/generator
+```
+
+---
+
+## Package Configuration
+
+### `interface_package`
+
+**Type:** String
+**Default:** `org.mycompany.api`
+
+Java package for generated interfaces.
+
+```yaml
+interface_package: com.example.myproject.api
+```
+
+### `implementation_package`
+
+**Type:** String
+**Default:** `org.mycompany.implementation`
+
+Java package for generated implementation classes.
+
+```yaml
+implementation_package: com.example.myproject.impl
+```
+
+### `type_package`
+
+**Type:** String
+**Default:** `org.mycompany.api.types`
+
+Java package for generated `*Type` factory interfaces.
+
+```yaml
+type_package: com.example.myproject.types
+```
+
+### `base_interface_package`
+
+**Type:** String
+**Default:** Same as `interface_package`
+
+Package for base interfaces (`GuestValue`, etc.).
+
+```yaml
+base_interface_package: com.example.common
+```
+
+### `base_interface_name`
+
+**Type:** String
+**Default:** `GraalValueBase`
+
+Name of the base interface that all generated interfaces extend.
+
+```yaml
+base_interface_name: PythonValue
+```
+
+### `strip_python_package_prefix`
+
+**Type:** String
+**Default:** (none)
+
+Python package prefix to strip when generating Java package names.
+
+```yaml
+strip_python_package_prefix: myproject.internal
+```
+
+---
+
+## Caching
+
+Caching significantly speeds up subsequent runs by avoiding repeated MyPy analysis.
+
+### `generator_cache_folder`
+
+**Type:** String (path)
+**Default:** (none - set explicitly in config)
+
+Directory for serialized AST cache. Current runtime also passes this folder to `set_mypy_cache_folder(...)`.
+
+```yaml
+generator_cache_folder: ./cache/generator
+```
+
+**Important:** Cache directories can contain absolute paths. Do not commit them to version control:
+
+```gitignore
+generator_cache/
+cache/
+```
+
+---
+
+## Generation Options
+
+### `generate_type_interface`
+
+**Type:** Boolean
+**Default:** `false`
+
+Generate `*Type` factory interfaces for creating Python objects from Java.
+
+```yaml
+generate_type_interface: true
+```
+
+When enabled, for a Python class `Rectangle`, generates:
+- `Rectangle` - Instance interface with methods
+- `RectangleType` - Factory interface with `newInstance()` method
+
+### `generate_base_classes`
+
+**Type:** Boolean
+**Default:** `false`
+
+Generate base implementation classes.
+
+```yaml
+generate_base_classes: true
+```
+
+### `generate_log_comments`
+
+**Type:** Boolean
+**Default:** `false`
+
+Add debug comments showing type resolution decisions.
+
+```yaml
+generate_log_comments: true
+```
+
+Useful for debugging type mapping issues.
+
+### `generate_timestamps`
+
+**Type:** Boolean
+**Default:** `true`
+
+Add generation timestamps to output files.
+
+```yaml
+generate_timestamps: false
+```
+
+### `generate_location`
+
+**Type:** Boolean
+**Default:** `true`
+
+Add source file location comments to generated code.
+
+```yaml
+generate_location: true
+```
+
+### `indentation`
+
+**Type:** Integer
+**Default:** `4`
+
+Number of spaces for indentation in generated code.
+
+```yaml
+indentation: 2
+```
+
+### `implementation_name_suffix`
+
+**Type:** String
+**Default:** `Impl`
+
+Suffix for implementation class names.
+
+```yaml
+implementation_name_suffix: Implementation
+```
+
+---
+
+## Filtering
+
+### `whitelist`
+
+**Type:** List of class/function specifications
+**Default:** (none - include everything)
+
+Only generate interfaces for specified items.
+
+```yaml
+whitelist:
+  # By class name
+  - class: MyClass
+
+  # By fully qualified name
+  - class: mymodule.MyClass
+
+  # By function name
+  - function: process_data
+
+  # Simple string (matches any type)
+  - PublicAPI
+```
+
+### `ignore`
+
+**Type:** List of strings
+**Default:** (none)
+
+Exclude items by name. Matched against simple names.
+
+```yaml
+ignore:
+  - _private_helper
+  - DebugClass
+  - test_function
+```
+
+---
+
+## Type Mappings
+
+### `type_mappings`
+
+**Type:** Map of Python type to Java type
+**Default:** (none)
+
+Override default Python-to-Java type translations.
+
+```yaml
+type_mappings:
+  numpy.ndarray: org.graalvm.polyglot.Value
+  pandas.DataFrame: com.example.DataFrameWrapper
+  mymodule.CustomType: com.example.JavaCustomType
+```
+
+### `any_java_type`
+
+**Type:** String
+**Default:** `org.graalvm.polyglot.Value`
+
+Java type used for Python's `Any` type and unresolved types.
+
+```yaml
+any_java_type: java.lang.Object
+```
+
+### `excluded_imports`
+
+**Type:** List of strings
+**Default:** `["java.lang.*"]`
+
+Import patterns to exclude from generated imports.
+
+```yaml
+excluded_imports:
+  - java.lang.*
+  - java.util.List
+```
+
+---
+
+## Native Image Support
+
+### `generate_proxy_config`
+
+**Type:** Boolean
+**Default:** `true`
+
+Generate GraalVM Native Image `proxy-config.json` for interface proxies.
+
+```yaml
+generate_proxy_config: true
+```
+
+### `path_proxy_config`
+
+**Type:** String (path)
+**Default:** `proxy-config.json`
+
+Output path for the proxy configuration file.
+
+```yaml
+path_proxy_config: ./META-INF/native-image/proxy-config.json
+```
+
+---
+
+## Type Export
+
+### `export_types`
+
+**Type:** Boolean
+**Default:** `true`
+
+Export type mappings to a file for documentation or tooling.
+
+```yaml
+export_types: true
+```
+
+### `export_files`
+
+**Type:** String (path)
+**Default:** `exportedTypes.txt`
+
+Output path for exported type mappings.
+
+```yaml
+export_files: ./docs/type-mappings.txt
+```
+
+### `export_include`
+
+**Type:** String
+**Default:** Same as `interface_package`
+
+Package prefix to include in export.
+
+```yaml
+export_include: com.example.api
+```
+
+### `export_exclude`
+
+**Type:** List of strings
+**Default:** `[]`
+
+Packages to exclude from type export.
+
+```yaml
+export_exclude:
+  - com.example.internal
+```
+
+---
+
+## Javadoc
+
+### `javadoc_folder`
+
+**Type:** String (path)
+**Default:** `./javadoc-cache`
+
+Cache directory for extracted Python docstrings.
+
+```yaml
+javadoc_folder: ./cache/javadoc
+```
+
+### `javadoc_generators`
+
+**Type:** List of class names
+**Default:** `["org.graalvm.python.javainterfacegen.generator.impl.JavadocGeneratorImpl"]`
+
+Javadoc generator implementations to use.
+
+```yaml
+javadoc_generators:
+  - org.graalvm.python.javainterfacegen.generator.impl.JavadocGeneratorImpl
+```
+
+### `javadoc_storage_manager`
+
+**Type:** String (class name)
+**Default:** `org.graalvm.python.javainterfacegen.generator.impl.JavadocStorageManagerYaml`
+
+Storage manager for javadoc cache.
+
+```yaml
+javadoc_storage_manager: org.graalvm.python.javainterfacegen.generator.impl.JavadocStorageManagerYaml
+```
+
+---
+
+## Licensing
+
+### `license_file`
+
+**Type:** String (path)
+**Default:** (none)
+
+License header file to include in generated sources.
+
+```yaml
+license_file: ./LICENSE_HEADER.txt
+```
+
+---
+
+## Advanced: Per-Item Configuration
+
+### File-Specific Settings
+
+Override settings for specific files:
+
+```yaml
+files:
+  - path: ./core.py
+    interface_package: com.example.core
+    generate_type_interface: true
+
+  - path: ./utils.py
+    interface_package: com.example.utils
+    ignore:
+      - debug_function
+
+target_folder: ./generated
+interface_package: com.example  # Default for unspecified files
+generator_cache_folder: ./cache/generator
+```
+
+### Class-Specific Settings
+
+Override settings for specific classes:
+
+```yaml
+files:
+  - path: ./module.py
+
+target_folder: ./generated
+interface_package: com.example
+generator_cache_folder: ./cache/generator
+
+classes:
+  MyClass:
+    overrides:
+      get_data:
+        return_type: com.example.CustomData
+      process:
+        return_type: java.util.List
+```
+
+### Function-Specific Settings
+
+Override settings for specific functions:
+
+```yaml
+files:
+  - path: ./module.py
+
+target_folder: ./generated
+interface_package: com.example
+generator_cache_folder: ./cache/generator
+
+functions:
+  calculate:
+    overrides:
+      return_type: java.math.BigDecimal
+```
+
+---
+
+## Generator Plugins
+
+### `function_generators`
+
+**Type:** List of class names
+**Default:** `["org.graalvm.python.javainterfacegen.generator.impl.JustInterfacesGeneratorImpl"]`
+
+Function generator implementations.
+
+```yaml
+function_generators:
+  - org.graalvm.python.javainterfacegen.generator.impl.JustInterfacesGeneratorImpl
+```
+
+### `name_generator`
+
+**Type:** String (class name)
+**Default:** `org.graalvm.python.javainterfacegen.generator.impl.NameGeneratorImpl`
+
+Name generator for Java identifiers.
+
+```yaml
+name_generator: org.graalvm.python.javainterfacegen.generator.impl.NameGeneratorImpl
+```
+
+### `type_generator`
+
+**Type:** String (class name)
+**Default:** `org.graalvm.python.javainterfacegen.generator.impl.TypeInterfaceGeneratorImpl`
+
+Type interface generator implementation.
+
+```yaml
+type_generator: org.graalvm.python.javainterfacegen.generator.impl.TypeInterfaceGeneratorImpl
+```
+
+---
+
+## Complete Example
+
+```yaml
+# Input
+files:
+  - path: ./src/core
+    interface_package: com.example.core
+  - path: ./src/utils
+    interface_package: com.example.utils
+    ignore:
+      - _debug
+
+# Output
+target_folder: ./generated-sources/java
+interface_package: com.example.api
+implementation_package: com.example.impl
+type_package: com.example.types
+
+# Caching
+generator_cache_folder: ./build/cache/generator
+javadoc_folder: ./build/cache/javadoc
+
+# Generation
+generate_type_interface: true
+generate_base_classes: false
+generate_log_comments: false
+generate_timestamps: true
+generate_location: true
+
+# Type mappings
+type_mappings:
+  numpy.ndarray: org.graalvm.polyglot.Value
+  pandas.DataFrame: com.example.DataFrameWrapper
+
+# Filtering
+whitelist:
+  - class: PublicAPI
+  - class: DataModel
+  - function: process
+
+ignore:
+  - _internal
+  - Test
+
+# Native Image
+generate_proxy_config: true
+path_proxy_config: ./META-INF/native-image/proxy-config.json
+
+# Export
+export_types: true
+export_files: ./docs/types.txt
+
+# License
+license_file: ./LICENSE_HEADER.txt
+```
+
+---
+
+## See Also
+
+- [Configuration Quick Start](configuration-quickstart.md) - Get started quickly
+- [Python to Java Type Translation](python-to-java-type-translation.md) - Type mapping details
+- [Architecture Overview](architecture.md) - System design

--- a/javainterfacegen/doc/mypy-integration.md
+++ b/javainterfacegen/doc/mypy-integration.md
@@ -1,0 +1,390 @@
+# MyPy Integration
+
+This document explains how the Java Interface Generator integrates with MyPy to extract type information from Python source code.
+
+## What is MyPy?
+
+[MyPy](http://mypy-lang.org/) is a static type checker for Python. It analyzes Python code with type annotations and produces a typed Abstract Syntax Tree (AST) with resolved type information. The Java Interface Generator uses MyPy's analysis results rather than implementing its own Python parser.
+
+## Why MyPy?
+
+1. **Accurate type inference**: MyPy resolves complex type expressions, generics, and type aliases
+2. **Standard compliance**: Supports PEP 484 type hints and `.pyi` stub files
+3. **Mature ecosystem**: Handles edge cases, inheritance, and Python's dynamic features
+4. **Maintained**: Active development and wide adoption
+
+## Integration Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         Java Side                                │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐  │
+│  │    Main     │───▶│  MypyHook   │───▶│  Node/Type Wrappers │  │
+│  │             │    │  (interface)│    │  (Java interfaces)  │  │
+│  └─────────────┘    └──────┬──────┘    └─────────────────────┘  │
+│                            │ GraalPy                             │
+│                            │ Polyglot                            │
+├────────────────────────────┼────────────────────────────────────┤
+│                            ▼                                     │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │                     Python Side                              ││
+│  │  ┌─────────────────┐    ┌──────────────────────────────┐   ││
+│  │  │  analyzePath.py │───▶│  mypy.build.build()          │   ││
+│  │  │  (entry point)  │    │  (MyPy API)                  │   ││
+│  │  └─────────────────┘    └──────────────────────────────┘   ││
+│  └─────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Java-Side Components
+
+### MypyHook Interface
+
+[`MypyHook`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/MypyHook.java) defines the Java interface to MyPy functionality:
+
+```java
+public interface MypyHook {
+    // Parse Python files and cache results
+    Map<String, Value> serialize_result(List<String> inputPaths, String cacheFile);
+
+    // Load previously cached parse results
+    Map<String, Value> load_result(String serializedData);
+
+    // Extract docstrings from Python source
+    Map<String, String> extract_docstrings(String path, String moduleFQN);
+
+    // Set MyPy cache directory
+    void set_mypy_cache_folder(String path);
+}
+```
+
+The interface is implemented via GraalPy's polyglot proxy mechanism:
+
+```java
+public static MypyHook fromContext(Context context) {
+    Value pythonBindings = context.getBindings("python");
+    pythonBindings.putMember("mypyhook_main",
+        context.eval("python", "import analyzePath"));
+    Value mypyHook = pythonBindings.getMember("mypyhook_main")
+        .getMember("analyzePath");
+    return mypyHook.as(MypyHook.class);
+}
+```
+
+### Node Wrappers
+
+The `mypy.nodes` package contains Java interfaces that wrap MyPy's AST nodes. Each wrapper accesses the underlying `Value` object from GraalPy:
+
+```java
+public interface MypyFile extends Node {
+    String FQN = "mypy.nodes.MypyFile";
+
+    String getName();           // Module name
+    String getPath();           // File path
+    String getFullname();       // Fully qualified module name
+    SymbolTable getNames();     // Exported symbols
+    List<Statement> getDefs();  // Top-level definitions
+
+    class MypyFileImpl extends GuestValueDefaultImpl implements MypyFile {
+        // Delegates to Value.getMember() calls
+    }
+}
+```
+
+Key node types:
+
+| MyPy Node | Java Interface | Key Methods |
+|-----------|----------------|-------------|
+| `MypyFile` | [`MypyFile`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/MypyFile.java) | `getNames()`, `getDefs()` |
+| `ClassDef` | [`ClassDef`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/ClassDef.java) | `getFullname()`, `getInfo()` |
+| `FuncDef` | [`FuncDef`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/FuncDef.java) | `getType()`, `getArguments()` |
+| `TypeInfo` | [`TypeInfo`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/TypeInfo.java) | `getBases()`, `getMro()`, `getNames()` |
+| `Var` | [`Var`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/nodes/Var.java) | `getType()`, `isProperty()` |
+
+### Type Wrappers
+
+The `mypy.types` package wraps MyPy's type representations:
+
+```java
+public interface Instance extends Type {
+    TypeInfo getType();      // Class being instantiated
+    List<Type> getArgs();    // Generic type arguments
+}
+
+public interface CallableType extends FunctionLike {
+    List<Type> getArgTypes();    // Parameter types
+    List<ArgKind> getArgKinds(); // ARG_POS, ARG_OPT, etc.
+    List<String> getArgNames();  // Parameter names
+    Type getRetType();           // Return type
+}
+```
+
+Key type classes:
+
+| MyPy Type | Java Interface | Represents |
+|-----------|----------------|------------|
+| `Instance` | [`Instance`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/Instance.java) | `MyClass`, `List[int]` |
+| `UnionType` | [`UnionType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/UnionType.java) | `Union[str, int]`, `Optional[T]` |
+| `CallableType` | [`CallableType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/CallableType.java) | `Callable[[int], str]` |
+| `TupleType` | [`TupleType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/TupleType.java) | `Tuple[int, str]` |
+| `TypeVarType` | [`TypeVarType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/TypeVarType.java) | `T` in `Generic[T]` |
+| `AnyType` | [`AnyType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/AnyType.java) | `Any` |
+| `NoneType` | [`NoneType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/NoneType.java) | `None` |
+
+## Python-Side Components
+
+### analyzePath.py
+
+[`analyzePath.py`](../src/main/resources/GRAALPY-VFS/org.graalvm.python/javainterfacegen/src/analyzePath.py) is the Python entry point that invokes MyPy:
+
+```python
+def extract_type_info(file_paths: list[str]):
+    """Run MyPy analysis on the given files."""
+    sources, options = process_options(file_paths)
+
+    # Configure MyPy for our use case
+    options.incremental = False
+    options.export_types = True
+    options.preserve_asts = True
+    options.include_docstrings = True
+    options.cache_dir = mypy_cache_dir
+
+    # Run MyPy build
+    result = build(sources, options=options)
+    return result
+
+def serialize_result(paths: list[str], cache_file_path: str):
+    """Parse files and serialize AST to JSON cache."""
+    result = extract_type_info(paths)
+
+    # Serialize each module's AST
+    ast_dict = {file: result.files[file].serialize()
+                for file in result.files}
+
+    with open(cache_file_path, 'w') as f:
+        json.dump(ast_dict, f, default=str, indent=2)
+
+    return result.files
+
+def load_result(json_filename: str) -> dict[str, MypyFile]:
+    """Load previously cached AST from JSON."""
+    with open(json_filename, 'r') as f:
+        ast_data = json.load(f)
+
+    # Deserialize each module
+    ast_nodes = {file: MypyFile.deserialize(ast)
+                 for file, ast in ast_data.items()}
+
+    # Fix up cross-references between modules
+    for file, mypy_file in ast_nodes.items():
+        fixup_module(mypy_file, ast_nodes, True)
+
+    return ast_nodes
+```
+
+### MyPy Configuration
+
+The tool configures MyPy with specific options:
+
+| Option | Value | Purpose |
+|--------|-------|---------|
+| `incremental` | `False` | Full analysis each time |
+| `export_types` | `True` | Preserve type information |
+| `preserve_asts` | `True` | Keep full AST for serialization |
+| `include_docstrings` | `True` | Extract documentation |
+| `follow_imports` | `"silent"` | Process imports without warnings |
+| `strict_optional` | `False` | Lenient Optional handling |
+
+## Parsing Flow
+
+### First Run (No Cache)
+
+```
+1. Main.parseWithMypy()
+   │
+   ├── 2. MypyHook.serialize_result(paths, cacheFile)
+   │      │
+   │      ├── 3. extract_type_info() ── MyPy builds typed AST
+   │      │
+   │      ├── 4. Serialize AST to JSON
+   │      │
+   │      └── 5. Return Map<String, MypyFile>
+   │
+   └── 6. Process MypyFile objects for code generation
+```
+
+### Subsequent Runs (With Cache)
+
+```
+1. Main.deserializeMypy()
+   │
+   ├── 2. MypyHook.load_result(cacheFile)
+   │      │
+   │      ├── 3. Load JSON from disk
+   │      │
+   │      ├── 4. MypyFile.deserialize() for each module
+   │      │
+   │      └── 5. fixup_module() to restore cross-references
+   │
+   └── 6. Return Map<String, MypyFile>
+```
+
+## Argument Kinds
+
+MyPy represents function parameter kinds via [`ArgKind`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/ArgKind.java):
+
+| Kind | Python Syntax | Description |
+|------|---------------|-------------|
+| `ARG_POS` | `def f(x)` | Required positional |
+| `ARG_OPT` | `def f(x=1)` | Optional positional |
+| `ARG_STAR` | `def f(*args)` | Variadic positional |
+| `ARG_NAMED` | `def f(*, x)` | Required keyword-only |
+| `ARG_NAMED_OPT` | `def f(*, x=1)` | Optional keyword-only |
+| `ARG_STAR2` | `def f(**kwargs)` | Variadic keyword |
+
+These are initialized from Python constants:
+
+```java
+public static void initFromContext(Context context) {
+    ARG_POS = context.eval("python", "import mypy.nodes; mypy.nodes.ARG_POS");
+    ARG_OPT = context.eval("python", "import mypy.nodes; mypy.nodes.ARG_OPT");
+    // ...
+}
+```
+
+## Docstring Extraction
+
+For `.pyi` stub files (which lack docstrings), the tool can extract docstrings from corresponding `.py` files:
+
+```python
+def extract_docstrings(file_path: str, moduleFQN: str) -> dict[str, str]:
+    """Extract docstrings using Python's ast module."""
+    with open(file_path, "r") as file:
+        source_code = file.read()
+
+    tree = ast.parse(source_code)
+    docstrings = {}
+
+    def process_node(node, parent_name=moduleFQN):
+        qualified_name = get_qualified_name(node, parent_name)
+        if qualified_name:
+            docstring = ast.get_docstring(node)
+            if docstring:
+                docstrings[qualified_name] = docstring
+        for child in ast.iter_child_nodes(node):
+            process_node(child, qualified_name)
+
+    process_node(tree)
+    return docstrings
+```
+
+## Caching
+
+### Why Cache?
+
+Running MyPy on GraalVM is significantly slower than on standard CPython due to GraalVM's JIT compilation overhead for Python code. Caching parsed results dramatically speeds up subsequent runs.
+
+### Cache Format
+
+The cache is a JSON file containing serialized MyPy AST:
+
+```json
+{
+  "mymodule": {
+    ".class": "MypyFile",
+    "name": "mymodule",
+    "path": "/path/to/mymodule.py",
+    "fullname": "mymodule",
+    "names": { ... },
+    "defs": [ ... ]
+  },
+  "mymodule.submodule": { ... }
+}
+```
+
+### Cache Location
+
+Configure via YAML:
+
+```yaml
+generator_cache_folder: ./gen_cache    # Current runtime: used for MyPy cache path and serialized AST JSON
+```
+
+### Cache Invalidation
+
+Caches contain **absolute file paths** and must be regenerated when:
+- Source files change
+- Files are moved
+- Working directory changes
+
+**Do not commit caches to version control.**
+
+## Troubleshooting
+
+### Stack Overflow
+
+Deep AST traversal may exhaust stack space:
+
+```bash
+MAVEN_OPTS="-Xss64M" mvn exec:java ...
+```
+
+### Slow First Run
+
+First run invokes full MyPy analysis. Subsequent runs use cached results. For large codebases, expect:
+- First run: Minutes
+- Cached run: Seconds
+
+### Missing Type Information
+
+If types show as `Any` or `Value`:
+
+1. Check Python source has type annotations
+2. Verify `.pyi` stub files are accessible
+3. Check `generator_cache_folder` permissions
+
+### Import Errors
+
+MyPy must be able to resolve imports. Ensure:
+- Virtual environment is activated
+- Dependencies are installed
+- `PYTHONPATH` includes necessary directories
+
+## Advanced Usage
+
+### Processing Multiple Modules
+
+```yaml
+files:
+  - path: ./mypackage
+  - path: ./mypackage/submodule.py
+```
+
+The tool finds the common root and processes all modules together.
+
+### Handling Stubs
+
+For libraries with `.pyi` stubs:
+
+```yaml
+files:
+  - path: /path/to/typeshed/stdlib/json/__init__.pyi
+```
+
+Docstrings are extracted from corresponding `.py` files when available.
+
+### Custom Type Mappings
+
+Override MyPy's type resolution:
+
+```yaml
+type_mappings:
+  numpy.ndarray: org.graalvm.polyglot.Value
+  pandas.DataFrame: com.example.DataFrameWrapper
+```
+
+## Related Documentation
+
+- [Architecture Overview](./architecture.md)
+- [Python to Java Type Translation](./python-to-java-type-translation.md)
+- [MyPy Documentation](https://mypy.readthedocs.io/)

--- a/javainterfacegen/doc/python-to-java-type-translation.md
+++ b/javainterfacegen/doc/python-to-java-type-translation.md
@@ -1,0 +1,204 @@
+# Python to Java Type Translation
+
+This document explains how Python types are translated to Java types in this repository.
+
+The core implementation lives in [TypeManager](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java), especially [`resolveJavaType(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:241), with additional generated helper type support in [TypeGeneratorImpl](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/TypeGeneratorImpl.java).
+
+## Overview
+
+Type translation is based on mypy's typed model (not direct runtime conversion). During generation:
+
+1. The tool reads mypy type nodes.
+2. It resolves each type to a Java type string.
+3. It emits imports/signatures.
+4. Unknown types are tracked as unresolved placeholders and later patched.
+
+Main entry point:
+- [`TypeManager.resolveJavaType(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:241)
+
+## Default built-in mappings
+
+The default mappings are initialized in [`TypeManager.init()`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:147).
+
+| Python type | Java type |
+|---|---|
+| `None` | `void` (or `Object` for args, see below) |
+| `Any` | `org.graalvm.polyglot.Value` |
+| `builtins.int` | `long` |
+| `builtins.float` | `double` |
+| `builtins.bool` | `boolean` |
+| `builtins.str` | `java.lang.String` |
+| `builtins.list` | `java.util.List` |
+| `builtins.tuple` | `java.util.List` (base mapping for `Instance`-based resolution) |
+| `builtins.dict` | `java.util.Map` |
+| `builtins.set` | `java.util.Set` |
+| `Union` | `org.graalvm.polyglot.Value` (fallback for complex unions) |
+
+Special-case override in instance resolution:
+- `typing.Coroutine` is translated directly to the default fallback Java type (typically `Value`) in [`resolveJavaType(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:247).
+
+Source:
+- [`registerType(...)` calls inside init](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:160)
+
+## Configurable mappings
+
+Custom mappings can be provided via configuration (`type_mappings`) and registered by [`TypeManager.registerTypes(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:196).
+
+This lets users override/add mappings for project-specific Python FQNs.
+
+## Resolution rules by type kind
+
+### 1) Instance types (`Instance`)
+
+Handled in [`resolveJavaType(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:242).
+
+Behavior:
+
+- Lookup Python FQN in registry.
+- If unknown, create unresolved placeholder (`pythonFQN#defaultJavaFQN`) using [`addUnresolvedType(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:471).
+- If generic args exist and mapped Java raw type is one of:
+  - `java.util.List`
+  - `java.util.Set`
+  - `java.util.Map`
+  then recursively translate generic arguments.
+
+Supported generic raw types are defined by [`javaTypeWithGenerics`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:121).
+
+### 2) Primitive boxing inside generics
+
+When a primitive appears in generics, it is boxed via [`javaPrimitiveToWrapper(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:417), e.g.:
+
+- `long` → `Long`
+- `boolean` → `Boolean`
+- `double` → `Double`
+
+Example:
+- Python `list[int]` → Java `List<Long>`
+
+### 3) Union types (`UnionType`)
+
+Handled in [`resolveJavaType(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:300).
+
+Rules:
+
+- If all members are `Literal[...]` with same fallback type: collapse to fallback type.
+- If union is exactly `Union[T, None]` (or reversed): return `T`, boxed when needed.
+- Otherwise: return default Java fallback (typically `Value`).
+
+This is a deliberate simplification for broad unions.
+
+### 4) Any type (`AnyType`)
+
+Returns default Java fallback type (usually `Value`):
+- [`AnyType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:353)
+
+### 5) Type aliases (`TypeAliasType`)
+
+Alias is transparent:
+- resolve alias target recursively.
+- [`TypeAliasType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:356)
+
+### 6) Tuple types (`TupleType`)
+
+Handled in [`TupleType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:358).
+
+Behavior:
+
+- If fallback is absent or `builtins.tuple`:
+  - heterogeneous/empty items → `Value[]` (the default Java fallback)
+  - homogeneous items → `<ResolvedElementType>[]`
+- If fallback exists and is not `builtins.tuple`, resolve fallback instance type instead.
+
+Note: this means concrete [`TupleType`](../src/main/java/org/graalvm/python/javainterfacegen/mypy/types/TupleType.java) nodes resolve to arrays, while the base mapping `builtins.tuple -> java.util.List` applies to instance-based translation paths.
+
+### 7) None type (`NoneType`)
+
+Special handling in [`NoneType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:385):
+
+- return type position: `void`
+- argument position (`isArg=true`): `Object`
+
+### 8) Type variables (`TypeVarType`)
+
+Handled in [`TypeVarType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:387):
+
+- `Self` resolves to current generated Java type name.
+- other type vars currently degrade to default fallback (`Value`).
+
+### 9) Literal types (`LiteralType`)
+
+Literal resolves to its fallback/base type:
+- [`LiteralType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:399)
+
+### 10) TypeType (`type[T]`)
+
+Currently resolves as inner item type `T`:
+- [`TypeType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:403)
+
+### 11) Not fully supported kinds
+
+These currently become unresolved/defaulted:
+
+- `CallableType`
+- `Overloaded`
+- `TypedDictType`
+- `UninhabitedType`
+
+See:
+- [`CallableType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:396)
+- [`Overloaded branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:406)
+- [`TypedDictType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:409)
+- [`UninhabitedType branch`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:382)
+
+## Unresolved type mechanism
+
+When a type is unknown during first pass, a placeholder form is emitted:
+- `pythonFQN#defaultJavaFQN`
+
+Later, [`handleUnresolved()`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:501) revisits generated files to:
+
+1. Replace placeholder with resolved mapped type, if available.
+2. Otherwise replace with default fallback and add TODO comments via [`addUnresolvedTypeComment(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java:563).
+
+## Generated helper classes for complex types
+
+For selected complex cases (notably some unions/lists), the generator may emit helper Java classes using [TypeGeneratorImpl](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/TypeGeneratorImpl.java). These classes typically contain:
+
+- `Optional<T>` fields for alternatives
+- constructors per alternative (+ empty constructor for `None` cases)
+- `isXxx()` checks
+- getters
+- `toString()`
+
+Relevant method:
+- [`TypeGeneratorImpl.getBody(...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/TypeGeneratorImpl.java:312)
+
+## Where type translation is consumed
+
+Function and property signatures use this translation in [FunctionGeneratorImpl](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/FunctionGeneratorImpl.java), especially:
+
+- return type resolution in [`create(FuncDef, ...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/FunctionGeneratorImpl.java:108) (resolution statement at line 116)
+- argument type resolution in [`create(FuncDef, ...)`](../src/main/java/org/graalvm/python/javainterfacegen/generator/impl/FunctionGeneratorImpl.java:193)
+
+## Representative examples
+
+- `builtins.str` → `String`
+- `builtins.int` → `long`
+- `builtins.set[builtins.int]` → `Set<Long>`
+- `builtins.dict[builtins.str, Any]` → `Map<String, Value>`
+- `Union[builtins.str, None]` → `String`
+- `Union[builtins.str, builtins.int]` → `Value` (fallback)
+- Unknown `module1.Unknown` → unresolved placeholder, then patched/defaulted
+
+## Tests validating behavior
+
+Primary tests are in:
+
+- [TypeManagerTest](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java)
+- [TypeGeneratorImplTest](../src/test/java/org/graalvm/python/javainterfacegen/generator/impl/TypeGeneratorImplTest.java)
+
+Notable assertions include:
+- builtins mappings ([basic test](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java:152))
+- list/set/map generic translation ([list test](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java:174), [dict test](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java:205))
+- union fallback/optional behavior ([union test](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java:242), [union+None test](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java:252))
+- alias/literal/typevar handling ([alias test](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java:228), [literal union test](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java:288), [typevar test](../src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java:272))

--- a/javainterfacegen/doc/usage-examples.md
+++ b/javainterfacegen/doc/usage-examples.md
@@ -1,0 +1,248 @@
+# Usage Examples
+
+This document provides detailed examples of using the Java Interface Generator.
+
+## Basic Module Generation
+
+The simplest use case: generate Java interfaces from Python functions.
+
+**Python source (`calculator.py`):**
+```python
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+def multiply(a: float, b: float) -> float:
+    """Multiply two numbers."""
+    return a * b
+```
+
+**Configuration (`calculator.yml`):**
+```yaml
+files:
+  - path: ./calculator.py
+target_folder: ./generated
+interface_package: com.example.calculator
+generator_cache_folder: ./cache/generator
+```
+
+**Generated Java interface:**
+```java
+package com.example.calculator;
+
+public interface Calculator {
+    /**
+     * Add two numbers.
+     */
+    long add(long a, long b);
+
+    /**
+     * Multiply two numbers.
+     */
+    double multiply(double a, double b);
+
+    static Calculator fromContext(Context context) {
+        // Factory method to create instance from GraalPy context
+    }
+}
+```
+
+**Using the generated interface:**
+```java
+try (Context context = Context.newBuilder("python").build()) {
+    Calculator calc = Calculator.fromContext(context);
+    long sum = calc.add(5, 3);        // Returns 8
+    double product = calc.multiply(2.5, 4.0);  // Returns 10.0
+}
+```
+
+---
+
+## Class Generation
+
+Generate interfaces for Python classes with type factory interfaces.
+
+**Python source (`shapes.py`):**
+```python
+class Rectangle:
+    """A rectangle shape."""
+
+    def __init__(self, width: float, height: float):
+        self.width = width
+        self.height = height
+
+    def area(self) -> float:
+        """Calculate the area."""
+        return self.width * self.height
+
+    def perimeter(self) -> float:
+        """Calculate the perimeter."""
+        return 2 * (self.width + self.height)
+```
+
+**Configuration:**
+```yaml
+files:
+  - path: ./shapes.py
+target_folder: ./generated
+interface_package: com.example.shapes
+generator_cache_folder: ./cache/generator
+generate_type_interface: true  # Generate factory interfaces
+```
+
+**Generated interfaces:**
+```java
+// Rectangle.java - Instance interface
+public interface Rectangle extends GuestValue {
+    double getWidth();
+    double getHeight();
+    double area();
+    double perimeter();
+
+    static boolean isInstance(Object object) { ... }
+    static Rectangle cast(Object o) { ... }
+}
+
+// RectangleType.java - Factory interface
+public interface RectangleType {
+    static RectangleType getPythonType(Context context) { ... }
+    default Rectangle newInstance(double width, double height) { ... }
+}
+```
+
+**Usage:**
+```java
+import org.graalvm.polyglot.Context;
+
+try (Context context = Context.newBuilder("python").build()) {
+    // Bind to the generated module/class interface for module-level functions and values
+    Shapes shapes = Shapes.fromContext(context);
+
+    // Use the generated *Type factory to construct Python class instances
+    RectangleType rectType = RectangleType.getPythonType(context);
+    Rectangle rect = rectType.newInstance(10.0, 5.0);
+
+    System.out.println(rect.area());       // 50.0
+    System.out.println(rect.perimeter());  // 30.0
+}
+```
+
+### Factory Method Patterns (`fromContext` vs `getPythonType`)
+
+Generated interfaces expose two common static entry points:
+
+- `fromContext(Context)` on module/namespace interfaces (for example, `Shapes.fromContext(context)`):
+  - Binds that generated interface to values/functions exported by the Python module in the provided `Context`.
+  - Use this when you want to call module-level functions or access module-level objects.
+
+- `getPythonType(Context)` on generated `*Type` interfaces (for example, `RectangleType.getPythonType(context)`):
+  - Binds to a specific Python class/type object in the same `Context`.
+  - Use this when you want to construct new Python objects (`newInstance(...)`) or otherwise interact with the Python type itself.
+
+Both methods require `org.graalvm.polyglot.Context` and should be used with the same active GraalPy context that loaded your Python code.
+
+---
+
+## Selective Generation with Whitelist
+
+Generate interfaces only for specific classes or functions.
+
+**Configuration:**
+```yaml
+files:
+  - path: ./large_module.py
+
+target_folder: ./generated
+interface_package: com.example.api
+generator_cache_folder: ./cache/generator
+
+# Only generate these specific items
+whitelist:
+  - class: ImportantClass
+  - class: AnotherClass
+  - function: main_function
+
+# Exclude internal helpers
+ignore:
+  - _internal_helper
+  - DebugClass
+```
+
+---
+
+## Custom Type Mappings
+
+Map Python types to specific Java types.
+
+**Configuration:**
+```yaml
+files:
+  - path: ./data_processing.py
+
+target_folder: ./generated
+interface_package: com.example.data
+generator_cache_folder: ./cache/generator
+
+# Map Python types to custom Java types
+type_mappings:
+  numpy.ndarray: org.graalvm.polyglot.Value
+  pandas.DataFrame: com.example.DataFrameWrapper
+  mymodule.CustomType: com.example.JavaCustomType
+```
+
+---
+
+## File-Specific Configuration
+
+Apply different settings to different files.
+
+**Configuration:**
+```yaml
+files:
+  - path: ./core.py
+    interface_package: com.example.core
+
+  - path: ./utils.py
+    interface_package: com.example.utils
+    ignore:
+      - debug_function
+
+target_folder: ./generated
+interface_package: com.example  # Default package
+generator_cache_folder: ./cache/generator
+```
+
+---
+
+## Class-Specific Configuration
+
+Override return types or other settings for specific classes.
+
+**Configuration:**
+```yaml
+files:
+  - path: ./module.py
+
+target_folder: ./generated
+interface_package: com.example
+generator_cache_folder: ./cache/generator
+
+classes:
+  MyClass:
+    # Override return types
+    overrides:
+      get_data:
+        return_type: com.example.CustomData
+
+functions:
+  process:
+    # Function-specific settings
+```
+
+---
+
+## See Also
+
+- [Configuration Quick Start](configuration-quickstart.md) - Common configuration patterns
+- [Configuration Reference](configuration-reference.md) - All options
+- [Python to Java Type Translation](python-to-java-type-translation.md) - Type mapping details

--- a/javainterfacegen/src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java
+++ b/javainterfacegen/src/main/java/org/graalvm/python/javainterfacegen/generator/TypeManager.java
@@ -38,46 +38,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-/*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
- *
- * The Universal Permissive License (UPL), Version 1.0
- *
- * Subject to the condition set forth below, permission is hereby granted to any
- * person obtaining a copy of this software, associated documentation and/or
- * data (collectively the "Software"), free of charge and under any and all
- * copyright rights in the Software, and any and all patent rights owned or
- * freely licensable by each licensor hereunder covering either (i) the
- * unmodified Software as contributed to or provided by such licensor, or (ii)
- * the Larger Works (as defined below), to deal in both
- *
- * (a) the Software, and
- *
- * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
- * one is included with the Software each a "Larger Work" to which the Software
- * is contributed by such licensors),
- *
- * without restriction, including without limitation the rights to copy, create
- * derivative works of, display, perform, and distribute the Software and make,
- * use, sell, offer for sale, import, export, have made, and have sold the
- * Software and the Larger Work(s), and to sublicense the foregoing rights on
- * either these or other terms.
- *
- * This license is subject to the following condition:
- *
- * The above copyright notice and either this complete permission notice or at a
- * minimum a reference to the UPL must be included in all copies or substantial
- * portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
 package org.graalvm.python.javainterfacegen.generator;
 
 import org.graalvm.polyglot.Value;
@@ -551,7 +511,7 @@ public class TypeManager {
 						String content = new String(Files.readAllBytes(path));
 						content = replace(content, key, finalJavaType, finalJavaType == null);
 						if (finalJavaType == null) {
-							content = addUnresolvedTypeCommnet(content, pythonType, finalJavaType);
+							content = addUnresolvedTypeComment(content, pythonType, finalJavaType);
 						}
 						Files.write(path, content.getBytes());
 					} catch (IOException ex) {
@@ -600,7 +560,7 @@ public class TypeManager {
 	 *            the Java type, that replace the Python type
 	 * @return
 	 */
-	protected String addUnresolvedTypeCommnet(String source, String pythonFQN, String javaFQN) {
+	protected String addUnresolvedTypeComment(String source, String pythonFQN, String javaFQN) {
 		StringBuilder updatedContent = new StringBuilder(source);
 		int endIndexMainSection = updatedContent.indexOf(UNKNOWN_TYPE_TEXT);
 		if (endIndexMainSection == -1) {

--- a/javainterfacegen/src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java
+++ b/javainterfacegen/src/test/java/org/graalvm/python/javainterfacegen/generator/TypeManagerTest.java
@@ -243,7 +243,7 @@ public class TypeManagerTest {
 	}
 
 	@Test
-	public void testResolveJavaTypeDir() throws Exception {
+	public void testResolveJavaTypeDict() throws Exception {
 		GeneratorContext context = createClassContext();
 		TypeManager typeManager = TypeManager.get();
 


### PR DESCRIPTION
# Description

  This PR prepares javainterfacegen for agent-assisted development and improves project onboarding/documentation quality.
  - Added AGENTS.md with project-specific operating instructions.
  - Rewrote README.md into a full guide (overview, quick start, config, debugging, build).
  - Added detailed documentation pages:
      - doc/configuration-quickstart.md
      - doc/configuration-reference.md
      - doc/usage-examples.md
      - doc/architecture.md
      - doc/mypy-integration.md
      - doc/python-to-java-type-translation.md
  - Minor code/test cleanup:
      - Renamed typoed method addUnresolvedTypeCommnet -> addUnresolvedTypeComment in TypeManager.
      - Renamed test method testResolveJavaTypeDir -> testResolveJavaTypeDict.
      - Removed duplicated file header block in TypeManager.java.

  Motivation/context:

  - Improve discoverability and correctness of docs for users and contributors.
  - Align repository documentation with current Maven-based invocation and configuration behavior.
  - Clean up small naming inconsistencies in generator code/tests.

  Dependencies:

  - No new runtime dependencies.
  - Build dependency expectation remains the same (graalpy-maven-plugin snapshot may need to be installed from the parent graalpy-extensions repo when not already available).

  Fixes # (issue)

  ## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

  # How Has This Been Tested?

  - [] Agents building the project.

  Test Configuration:

  - codex 
  # Checklist:

  - [ x] My code follows the style guidelines of this project
  - [x ] I have performed a self-review of my own code
  - [ x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [ x] My changes generate no new warnings
  - [ x] I have added tests that prove my fix is effective or that my feature works
  - [ x] New and existing unit tests pass locally with my changes
  - [ x] Any dependent changes have been merged and published in downstream modules
