### PR TITLE
Include Java records in generated stubs

### DIFF
--- a/pyinterfacegen/doclet/src/main/kotlin/org/graalvm/python/pyinterfacegen/J2PyiDoclet.kt
+++ b/pyinterfacegen/doclet/src/main/kotlin/org/graalvm/python/pyinterfacegen/J2PyiDoclet.kt
@@ -73,11 +73,17 @@ class J2PyiDoclet : Doclet {
 
         compileAssumedTypedPkgMatchers()
 
-        // Build an intermediate representation for all included types (classes, interfaces, enums) honoring include/exclude and visibility.
+        // Build an intermediate representation for all included types (classes, records, interfaces, enums)
+        // honoring include/exclude and visibility.
         val typeIRs = environment.includedElements
             .asSequence()
             .filterIsInstance<TypeElement>()
-            .filter { it.kind == ElementKind.CLASS || it.kind == ElementKind.INTERFACE || it.kind == ElementKind.ENUM }
+            .filter {
+                it.kind == ElementKind.CLASS ||
+                    it.kind == ElementKind.RECORD ||
+                    it.kind == ElementKind.INTERFACE ||
+                    it.kind == ElementKind.ENUM
+            }
             .filter { shouldIncludeType(it) }
             .mapNotNull { maybeBuildTypeIR(it) }
             .sortedBy { it.qualifiedName }


### PR DESCRIPTION
## Summary
- include ElementKind.RECORD when collecting types for stub generation
- allow public Java records to generate .pyi files like other public classes

## Why
pyinterfacegen currently filters records out before IR generation, so public records never get stubs even though other generated stubs may reference them. In Allay's API this leaves missing stubs for types such as CommandResult, PluginDependency, and Skin.

This fixes issue #62.

## Verification
- regenerated Allay API stubs with this change and confirmed public records now emit .pyi files
- verified generated examples such as CommandResult.pyi, PluginDependency.pyi, and Skin.pyi are present after regeneration