### PR TITLE
Improve integration tests support for extra Maven repositories

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,6 +110,18 @@ some necessary arguments to the test driver Python script. You can pass addition
 unittest framework using the system property `integration.test.args`, for example, tests to execute
 or verbosity level.
 
+The tests can be run against artifacts released on Maven Central or in extra Maven repositories
+(local and remote). Example invocation:
+
+```
+JAVA_HOME=/path/to/graalvm python3 integration-tests/run.py -v --no-clean \
+    --native-image smoke --skip-long-running \
+    --gradle-java-home /path/to/jdk21 \
+    --graalpy-version version_to_be_tested_eg_25.0.3-SNAPSHOT \
+    --extra-maven-repos https://some-repository/with/the/artifacts/ \
+    -k test_gradle_generated_app test_gradle_plugin
+```
+
 ## Changing version
 
 - Update the top-level `pom.xml` property `revision`; everything else should be derived from it.

--- a/integration-tests/gradle/gradle-test-project/gradle.properties
+++ b/integration-tests/gradle/gradle-test-project/gradle.properties
@@ -1,4 +1,4 @@
-# the jdk used to run the gradle demon has to be <= 22
+# the JDK used to run the Gradle daemon has to be JDK 21
 # this will be replaced by the integration tests:
 # pass -Dgradle.java.home to Maven or --gradle-java-home to the Python test driver
 org.gradle.java.home={GRADLE_JAVA_HOME}

--- a/integration-tests/run.py
+++ b/integration-tests/run.py
@@ -56,11 +56,9 @@ if __name__ == "__main__":
     parser.add_argument('--skip-long-running', action='store_true', help='Skips long running tests')
     parser.add_argument('--no-clean', action='store_true', help='Do not clean the test temporary directories (for post-mortem debugging)')
     parser.add_argument('--jbang-graalpy-version', help='GraalPy version to use for JBang tests, overrides --graalpy-version')
-    parser.add_argument('--gradle-java-home', default=os.environ['JAVA_HOME'], help='Java to be used to run Gradle (by default $JAVA_HOME)')
+    parser.add_argument('--gradle-java-home', default=os.environ['JAVA_HOME'], help='JDK 21 to be used to run Gradle (by default $JAVA_HOME)')
     parser.add_argument('--help-unittest', action='store_true', help='Print help of the stdlib unittest CLI and exits')
-    parser.add_argument('--extra-maven-repos', default='', help='Semicolon separated list of additional Maven repositories. '
-                                                                'If GraalPy Maven archetype is not available in central, '
-                                                                'then it must be available in the first extra repository.')
+    parser.add_argument('--extra-maven-repos', default='', help='Semicolon separated list of additional Maven repositories')
     args, remaining_args = parser.parse_known_args()
 
     if args.help_unittest:

--- a/integration-tests/test_gradle_plugin.py
+++ b/integration-tests/test_gradle_plugin.py
@@ -56,6 +56,8 @@ def append(file, txt):
 
 
 class GradlePluginTestBase(util.BuildToolTestBase):
+    EXPECTED_GRADLE_JAVA_VERSION = "21"
+
     def __init__(self, build_file_name:str, settings_file_name:str, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.build_file_name = build_file_name
@@ -65,9 +67,34 @@ class GradlePluginTestBase(util.BuildToolTestBase):
     def setUpClass(cls):
         super().setUpClass()
         cls.test_prj_path = os.path.join(os.path.dirname(__file__), "gradle", "gradle-test-project")
+        cls.check_gradle_java_home(util.gradle_java_home)
 
-    def target_dir_name_sufix(self, target_dir):
-        pass
+    @staticmethod
+    def gradle_string(value):
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    def insert_extra_maven_repositories(self, file, indent):
+        marker = f"{indent}mavenLocal()\n"
+        repos = "".join(f"{indent}{self.extra_maven_repository(repo)}\n" for repo in util.extra_maven_repos)
+        util.replace_in_file(file, marker, marker + repos, count=1)
+
+    @classmethod
+    def java_version(cls, java_home):
+        release_file = os.path.join(java_home, "release")
+        assert os.path.exists(release_file), f"cannot find JDK release file '{release_file}'"
+        with open(release_file, "r") as f:
+            for line in f:
+                if line.startswith("JAVA_VERSION="):
+                    return line.split("=", 1)[1].strip().strip('"')
+        return None
+
+    @classmethod
+    def check_gradle_java_home(cls, java_home):
+        java_version = cls.java_version(java_home)
+        assert java_version == cls.EXPECTED_GRADLE_JAVA_VERSION or java_version.startswith(cls.EXPECTED_GRADLE_JAVA_VERSION + "."), (
+            f"Gradle integration tests need Java {cls.EXPECTED_GRADLE_JAVA_VERSION} to run Gradle and its plugins, "
+            f"but '{java_home}' is Java {java_version} (parsed from {java_home}/release). Pass --gradle-java-home with a JDK 21 runtime."
+        )
 
     def copy_build_files(self, target_dir):
         build_file = os.path.join(target_dir, self.build_file_name)
@@ -76,13 +103,14 @@ class GradlePluginTestBase(util.BuildToolTestBase):
         settings_file = os.path.join(target_dir, self.settings_file_name)
         shutil.copyfile(os.path.join(os.path.dirname(__file__), "gradle", "scripts", self.settings_file_name), settings_file)
         if util.extra_maven_repos:
-            mvn_repos = ""
-            for idx, custom_repo in enumerate(util.extra_maven_repos):
-                mvn_repos += f"maven {{ url \"{custom_repo}\" }}\n    "
-            util.replace_in_file(build_file,
-                                 "repositories {", f"repositories {{\n    mavenLocal()\n    {mvn_repos}")
-            util.replace_in_file(settings_file,
-                                 "repositories {", f"repositories {{\n        {mvn_repos}")
+            self.insert_extra_maven_repositories(build_file, "    ")
+            self.insert_extra_maven_repositories(settings_file, "        ")
+
+    def target_dir_name_sufix(self, target_dir):
+        pass
+
+    def extra_maven_repository(self, repo):
+        pass
 
     def empty_plugin(self):
         pass
@@ -122,9 +150,6 @@ class GradlePluginTestBase(util.BuildToolTestBase):
                     shutil.move(os.path.join(root, file), os.path.join(root, file[0:len(file)- 1] + "java"))
 
         self.copy_build_files(target_dir)
-
-        # at the moment the gradle demon does not run with jdk <= 22
-        assert util.gradle_java_home, "in order to run standalone gradle tests, the 'GRADLE_JAVA_HOME' env var has to be set to a jdk <= 22"
         util.replace_in_file(os.path.join(target_dir, "gradle.properties"), "{GRADLE_JAVA_HOME}", util.gradle_java_home.replace("\\", "\\\\"))
 
         meta_inf_native_image_dir = os.path.join(target_dir, "src", "main", "resources", "META-INF", "native-image")
@@ -659,6 +684,9 @@ class GradlePluginGroovyTest(GradlePluginTestBase):
     def target_dir_name_sufix(self):
         return "_groovy"
 
+    def extra_maven_repository(self, repo):
+        return f'maven {{ url "{self.gradle_string(repo)}" }}'
+
     def empty_plugin(self):
         return f"graalPy {{  }}"
 
@@ -821,6 +849,9 @@ class GradlePluginKotlinTest(GradlePluginTestBase):
 
     def target_dir_name_sufix(self):
         return "_kotlin"
+
+    def extra_maven_repository(self, repo):
+        return f'maven {{ url = uri("{self.gradle_string(repo)}") }}'
 
     def empty_plugin(self):
         return f"graalPy {{  }}"

--- a/integration-tests/test_maven_plugin.py
+++ b/integration-tests/test_maven_plugin.py
@@ -44,7 +44,7 @@ import glob
 import shutil
 import sys
 import textwrap
-import urllib
+import xml.sax.saxutils
 
 import util
 from util import TemporaryTestDirectory, Logger, long_running_test, native_image_all
@@ -115,45 +115,72 @@ class MavenPluginTest(util.BuildToolTestBase):
         super().setUpClass()
         cls.archetypeGroupId = "org.graalvm.python"
         cls.archetypeArtifactId = "graalpy-archetype-polyglot-app"
-        cls.pluginArtifactId = "graalpy-maven-plugin"
-        cls.extraRemoteRepo = None
 
-        found = False
-        log = []
-        for custom_repo in util.extra_maven_repos:
-            url = urllib.parse.urlparse(custom_repo)
-            if url.scheme != "file":
-                log.append(f"'{custom_repo}' was identified as a remote repo and skipped")
-                if not cls.extraRemoteRepo:
-                    cls.extraRemoteRepo = custom_repo
-                continue
+    @classmethod
+    def _write_archetype_driver_pom(cls, tmpdir):
+        repositories = []
+        plugin_repositories = []
+        for idx, repo in enumerate(util.extra_maven_repos):
+            repo_id = f"extra-maven-repo-{idx}"
+            repo_url = xml.sax.saxutils.escape(repo)
+            repositories.append(textwrap.dedent(f"""\
+                <repository>
+                  <id>{repo_id}</id>
+                  <url>{repo_url}</url>
+                  <releases>
+                    <enabled>true</enabled>
+                  </releases>
+                  <snapshots>
+                    <enabled>true</enabled>
+                  </snapshots>
+                </repository>"""))
+            plugin_repositories.append(textwrap.dedent(f"""\
+                <pluginRepository>
+                  <id>{repo_id}</id>
+                  <url>{repo_url}</url>
+                  <releases>
+                    <enabled>true</enabled>
+                  </releases>
+                  <snapshots>
+                    <enabled>true</enabled>
+                  </snapshots>
+                </pluginRepository>"""))
 
-            base_path = urllib.parse.unquote(url.path)
-
-            if not cls._install_artifact_from_local_repo(base_path, custom_repo, cls.archetypeArtifactId, log):
-                continue
-            if not cls._install_artifact_from_local_repo(base_path, custom_repo, cls.pluginArtifactId, log):
-                continue
-
-            found = True
-            break
-
-        if util.extra_maven_repos and not found and not cls.extraRemoteRepo:
-            print("WARNING: extra Maven repos passed, but could not find GraalPy Maven archetype "
-                  "in any of the local repos and there is no extra remote repo. This is OK only if "
-                  "GraalPy Maven archetype of the required version is available at Mavencentral, "
-                  "otherwise the tests will fail to generate the example application. Searched these repositories: \n"
-                  '\n'.join(['    ' + x for x in log]))
+        repositories_xml = textwrap.indent("\n".join(repositories), "    ")
+        plugin_repositories_xml = textwrap.indent("\n".join(plugin_repositories), "    ")
+        pom = os.path.join(str(tmpdir), "graalpy-archetype-driver-pom.xml")
+        lines = [
+            '<project xmlns="http://maven.apache.org/POM/4.0.0"',
+            '         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+            '         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">',
+            "  <modelVersion>4.0.0</modelVersion>",
+            "  <groupId>archetype.it</groupId>",
+            "  <artifactId>graalpy-archetype-driver</artifactId>",
+            "  <version>1.0-SNAPSHOT</version>",
+        ]
+        if repositories:
+            lines += [
+                "  <repositories>",
+                repositories_xml,
+                "  </repositories>",
+                "  <pluginRepositories>",
+                plugin_repositories_xml,
+                "  </pluginRepositories>",
+            ]
+        lines.append("</project>")
+        with open(pom, "w") as f:
+            f.write("\n".join(lines) + "\n")
+        return pom
 
     def generate_app(self, tmpdir, target_dir, target_name, pom_template=None, group_id="archetype.it", package="it.pkg", log=Logger()):
-        extra_repo = []
-        if MavenPluginTest.extraRemoteRepo:
-            # assuming the first repo has the archetype
-            extra_repo = [f'-DarchetypeRepository={MavenPluginTest.extraRemoteRepo}']
-
+        driver_pom = self._write_archetype_driver_pom(tmpdir)
         cmd = util.GLOBAL_MVN_CMD + [
-            "archetype:generate",
+            "-U",
+            "-f",
+            driver_pom,
+            "org.apache.maven.plugins:maven-archetype-plugin:3.4.1:generate",
             "-B",
+            "-DarchetypeCatalog=internal",
             f"-DarchetypeGroupId={self.archetypeGroupId}",
             f"-DarchetypeArtifactId={self.archetypeArtifactId}",
             f"-DarchetypeVersion={self.graalvmVersion}",
@@ -161,7 +188,8 @@ class MavenPluginTest(util.BuildToolTestBase):
             f"-DgroupId={group_id}",
             f"-Dpackage={package}",
             "-Dversion=0.1-SNAPSHOT",
-        ] + extra_repo
+            f"-DoutputDirectory={tmpdir}",
+        ]
         out, return_code = util.run_cmd(cmd, self.env, cwd=str(tmpdir), logger=log)
         util.check_ouput("BUILD SUCCESS", out, logger=log)
 

--- a/integration-tests/util.py
+++ b/integration-tests/util.py
@@ -215,12 +215,12 @@ def get_executable(file):
     return None
 
 
-def replace_in_file(file, str, replace_str):
+def replace_in_file(file, str, replace_str, count=-1):
     with open(file, "r") as f:
         contents = f.read()
     assert str in contents, f"cannot find '{str}' in file '{file}' with contents:\n {contents}\n------"
     with open(file, "w") as f:
-        f.write(contents.replace(str, replace_str))
+        f.write(contents.replace(str, replace_str, count))
 
 
 def replace_main_body(filename, new_main_body):


### PR DESCRIPTION
- Switched Maven archetype generation to an explicit driver POM using `maven-archetype-plugin:3.4.1`, so released/pre-release artifacts can be resolved from extra repositories.
- Gradle integration-test handling to requires and checks JDK 21 for Gradle.