### PR TITLE
Migrate GraalPyResources to Context.Builder#apply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         shell: bash
 
       - name: Run Maven install
-        run: mvn --batch-mode -Dgradle.java.home=$GRADLE_JAVA_HOME -DskipTests install
+        run: ./mvnw --batch-mode -Dgradle.java.home=$GRADLE_JAVA_HOME -DskipTests install
         shell: bash
 
       - name: Install JBang (Linux/macOS)
@@ -192,7 +192,7 @@ jobs:
       - name: Run integration tests
         id: tests_run
         run: |
-          mvn --batch-mode -Dgradle.java.home=$GRADLE_JAVA_HOME exec:java@integration-tests -Dintegration.tests.args="${{ matrix.test_name }} ${{ matrix.extra_test_args }} $TEST_FLAGS"
+          ./mvnw --batch-mode -Dgradle.java.home=$GRADLE_JAVA_HOME exec:java@integration-tests -Dintegration.tests.args="${{ matrix.test_name }} ${{ matrix.extra_test_args }} $TEST_FLAGS"
         shell: bash
 
       # /var/folders/sw/**/T/jbang*native-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Run integration tests
         id: tests_run
         run: |
-          ./mvnw --batch-mode -Dgradle.java.home=$GRADLE_JAVA_HOME exec:java@integration-tests -Dintegration.tests.args="${{ matrix.test_name }} ${{ matrix.extra_test_args }} $TEST_FLAGS"
+          ./mvnw --batch-mode -N -Dgradle.java.home=$GRADLE_JAVA_HOME exec:java@integration-tests -Dintegration.tests.args="${{ matrix.test_name }} ${{ matrix.extra_test_args }} $TEST_FLAGS"
         shell: bash
 
       # /var/folders/sw/**/T/jbang*native-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ under the "GraalPy Embedding" section.
 
 ## 25.1.0
 
+* `GraalPyResources` now provides `of(VirtualFileSystem)` and
+`of(Path)` resource configurations that can be applied to an existing
+`Context.Builder` with `Context.Builder.apply(...)`. The older
+`createContext()` and `contextBuilder(...)` factory methods are deprecated and
+include migration snippets in the API reference documentation.
+
 * API reference documentation for the embedding module is now published at
 [oracle.github.io/graalpy-extensions](https://oracle.github.io/graalpy-extensions/latest/org.graalvm.python.embedding/module-summary.html).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ under the "GraalPy Embedding" section.
 
 ## 25.1.0
 
-* `GraalPyResources` now provides `of(VirtualFileSystem)` and
-`of(Path)` resource configurations that can be applied to an existing
-`Context.Builder` with `Context.Builder.apply(...)`. The older
+* `GraalPyResources` now provides `forVirtualFileSystem(VirtualFileSystem)` and
+`forExternalDirectory(Path)` resource configurations that can be applied to an
+existing `Context.Builder` with `Context.Builder.apply(...)`. The older
 `createContext()` and `contextBuilder(...)` factory methods are deprecated and
 include migration snippets in the API reference documentation.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Collection of tools and libraries that extend [GraalPy](https://graalvm.org/pyth
 Java library with utility classes useful when embedding GraalPy.
 
 * `VirtualFileSystem`: implementation of the [FileSystem SPI](https://www.graalvm.org/sdk/javadoc/org/graalvm/polyglot/io/FileSystem.html) backed by Java resources and tailored for use with GraalPy Maven/Gradle plugin (see below).
-* `GraalPyResources`: factory methods for creating a [Context](https://www.graalvm.org/sdk/javadoc/org/graalvm/polyglot/Context.html) configured with the `VirtualFileSystem`.
+* `GraalPyResources`: reusable [Context.Builder](https://www.graalvm.org/sdk/javadoc/org/graalvm/polyglot/Context.Builder.html) templates for configuring GraalPy resources, including the `VirtualFileSystem`.
 * `PositionalArguments` and `KeywordArguments`: provide way to pass positional and keyword arguments via the generic [Context API](https://www.graalvm.org/sdk/javadoc/org/graalvm/polyglot/Context.html).
 
 See the [GraalPy Embedding API Javadocs](https://oracle.github.io/graalpy-extensions/latest/org.graalvm.python.embedding/org/graalvm/python/embedding/package-summary.html) for the full class and module reference.

--- a/configs/eclipse-java-formatter.xml
+++ b/configs/eclipse-java-formatter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="22">
+  <profile kind="CodeFormatterProfile" name="graalpy" version="22">
+    <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+  </profile>
+</profiles>

--- a/graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/src/main/java/GraalPy.java
+++ b/graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/src/main/java/GraalPy.java
@@ -42,9 +42,12 @@
 package ${package};
 
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.PolyglotAccess;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.io.IOAccess;
 import java.io.IOException;
 import org.graalvm.python.embedding.GraalPyResources;
 import org.graalvm.python.embedding.VirtualFileSystem;
@@ -54,7 +57,9 @@ public class GraalPy {
 
     public static void main(String[] args) {
         VirtualFileSystem vfs = VirtualFileSystem.newBuilder().resourceDirectory("GRAALPY-VFS/${groupId}/${artifactId}").build();
-        try (Context context = GraalPyResources.contextBuilder(vfs).build()) {
+        try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
+                .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL).apply(GraalPyResources.of(vfs))
+                .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             Source source;
             try {
                 source = Source.newBuilder(PYTHON, "import hello", "<internal>").internal(true).build();

--- a/graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/src/main/java/GraalPy.java
+++ b/graalpy-archetype-polyglot-app/src/main/resources/archetype-resources/src/main/java/GraalPy.java
@@ -58,7 +58,7 @@ public class GraalPy {
     public static void main(String[] args) {
         VirtualFileSystem vfs = VirtualFileSystem.newBuilder().resourceDirectory("GRAALPY-VFS/${groupId}/${artifactId}").build();
         try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
-                .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL).apply(GraalPyResources.of(vfs))
+                .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL).apply(GraalPyResources.forVirtualFileSystem(vfs))
                 .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             Source source;
             try {

--- a/graalpy-maven-plugin/src/main/java/org/graalvm/python/maven/plugin/AbstractGraalPyMojo.java
+++ b/graalpy-maven-plugin/src/main/java/org/graalvm/python/maven/plugin/AbstractGraalPyMojo.java
@@ -264,7 +264,7 @@ public abstract class AbstractGraalPyMojo extends AbstractMojo {
 			if (externalDirectory != null && Files.exists(srcPath)) {
 				getLog().warn(String.format(
 						"Found Java resources directory %s, however, the GraalPy Maven plugin is configured to use <externalDirectory> instead of Java resources. "
-								+ "The files from %s will not be available in Contexts created using GraalPyResources#contextBuilder(Path). Move them to '%s' if "
+								+ "The files from %s will not be available in Contexts configured using Context.Builder#apply(GraalPyResources.of(Path)). Move them to '%s' if "
 								+ "you want to make them available when using external directory, or use Java resources by removing <externalDirectory> option.",
 						srcPath, srcPath, Path.of(externalDirectory, "src")));
 			}

--- a/graalpy-maven-plugin/src/main/java/org/graalvm/python/maven/plugin/AbstractGraalPyMojo.java
+++ b/graalpy-maven-plugin/src/main/java/org/graalvm/python/maven/plugin/AbstractGraalPyMojo.java
@@ -264,7 +264,7 @@ public abstract class AbstractGraalPyMojo extends AbstractMojo {
 			if (externalDirectory != null && Files.exists(srcPath)) {
 				getLog().warn(String.format(
 						"Found Java resources directory %s, however, the GraalPy Maven plugin is configured to use <externalDirectory> instead of Java resources. "
-								+ "The files from %s will not be available in Contexts configured using Context.Builder#apply(GraalPyResources.of(Path)). Move them to '%s' if "
+								+ "The files from %s will not be available in Contexts configured using Context.Builder#apply(GraalPyResources.forExternalDirectory(Path)). Move them to '%s' if "
 								+ "you want to make them available when using external directory, or use Java resources by removing <externalDirectory> option.",
 						srcPath, srcPath, Path.of(externalDirectory, "src")));
 			}

--- a/graalpy-maven-plugin/src/main/java/org/graalvm/python/maven/plugin/AbstractGraalPyMojo.java
+++ b/graalpy-maven-plugin/src/main/java/org/graalvm/python/maven/plugin/AbstractGraalPyMojo.java
@@ -321,7 +321,7 @@ public abstract class AbstractGraalPyMojo extends AbstractMojo {
 		Path javaExecutable = java == null || java.isBlank() ? null : Path.of(java);
 		// Maven's public Toolchain API exposes the selected executable, but not the
 		// matching JDK version. JavaToolchain will infer it from the selected JDK.
-		return JavaToolchain.fromJavaExecutable(javaExecutable, (String) null);
+		return JavaToolchain.fromJavaExecutable(javaExecutable);
 	}
 
 	protected static String getGraalPyVersion(MavenProject project) throws IOException {

--- a/graalpy-sandboxed-mcp/pom.xml
+++ b/graalpy-sandboxed-mcp/pom.xml
@@ -282,7 +282,9 @@
                 <version>2.46.1</version>
                 <configuration>
                     <java>
-                        <eclipse/>
+                        <eclipse>
+                            <file>../configs/eclipse-java-formatter.xml</file>
+                        </eclipse>
                         <trimTrailingWhitespace/>
                         <removeWildcardImports/>
                     </java>

--- a/integration-tests/gradle/gradle-test-project/src/main/java/org/example/GraalPy.j
+++ b/integration-tests/gradle/gradle-test-project/src/main/java/org/example/GraalPy.j
@@ -58,7 +58,7 @@ public class GraalPy {
     public static void main(String[] args) {
         try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
                 .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                .apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
                 .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             Source source;
             try {

--- a/integration-tests/test_gradle_plugin.py
+++ b/integration-tests/test_gradle_plugin.py
@@ -355,8 +355,8 @@ class GradlePluginTestBase(util.BuildToolTestBase):
                 "package org.example;",
                 "package org.example;\nimport java.nio.file.Path;")
             util.replace_in_file(os.path.join(target_dir, "src", "main", "java", "org", "example", "GraalPy.java"),
-                "GraalPyResources.of(VirtualFileSystem.create())",
-                "GraalPyResources.of(Path.of(\"" + (resources_dir if "win32" != sys.platform else resources_dir.replace("\\", "\\\\")) + "\"))")
+                "GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create())",
+                "GraalPyResources.forExternalDirectory(Path.of(\"" + (resources_dir if "win32" != sys.platform else resources_dir.replace("\\", "\\\\")) + "\"))")
 
             # patch build.gradle
             append(build_file, self.packages_termcolor_resource_dir(resources_dir))
@@ -604,11 +604,11 @@ class GradlePluginTestBase(util.BuildToolTestBase):
                                          .build();
                                  try (Context context1 = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
                                         .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                                        .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                                        .apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
                                         .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build();
                                       Context context2 = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
                                         .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                                        .apply(GraalPyResources.of(vfs))
+                                        .apply(GraalPyResources.forVirtualFileSystem(vfs))
                                         .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
                                      int index = 0;
                                      for (Context ctx: new Context[] {context1, context2}) {

--- a/integration-tests/test_gradle_plugin.py
+++ b/integration-tests/test_gradle_plugin.py
@@ -355,8 +355,8 @@ class GradlePluginTestBase(util.BuildToolTestBase):
                 "package org.example;",
                 "package org.example;\nimport java.nio.file.Path;")
             util.replace_in_file(os.path.join(target_dir, "src", "main", "java", "org", "example", "GraalPy.java"),
-                "GraalPyResources.createContext()",
-                "GraalPyResources.contextBuilder(Path.of(\"" + (resources_dir if "win32" != sys.platform else resources_dir.replace("\\", "\\\\")) + "\")).build()")
+                "GraalPyResources.of(VirtualFileSystem.create())",
+                "GraalPyResources.of(Path.of(\"" + (resources_dir if "win32" != sys.platform else resources_dir.replace("\\", "\\\\")) + "\"))")
 
             # patch build.gradle
             append(build_file, self.packages_termcolor_resource_dir(resources_dir))
@@ -602,8 +602,14 @@ class GradlePluginTestBase(util.BuildToolTestBase):
                                    org.graalvm.python.embedding.VirtualFileSystem.newBuilder()
                                          .resourceDirectory("GRAALPY-VFS/org.graalvm.python.tests/gradleapp1")
                                          .build();
-                                 try (Context context1 = GraalPyResources.createContext();
-                                      Context context2 = GraalPyResources.contextBuilder(vfs).build()) {
+                                 try (Context context1 = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
+                                        .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
+                                        .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                                        .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build();
+                                      Context context2 = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
+                                        .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
+                                        .apply(GraalPyResources.of(vfs))
+                                        .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
                                      int index = 0;
                                      for (Context ctx: new Context[] {context1, context2}) {
                                          ctx.eval("python", "import hello");

--- a/integration-tests/test_jbang_integration.py
+++ b/integration-tests/test_jbang_integration.py
@@ -252,8 +252,8 @@ def hello():
                 f"//PIP termcolor==2.2\n//PYTHON_RESOURCES_DIRECTORY {resources_dir}")
         rd = resources_dir.replace("\\", "\\\\")
         util.replace_in_file(hello_java_file,
-                "GraalPyResources.createContext()",
-                f"GraalPyResources.contextBuilder(java.nio.file.Path.of(\"{rd}\")).build()")
+                "GraalPyResources.of(VirtualFileSystem.create())",
+                f"GraalPyResources.of(java.nio.file.Path.of(\"{rd}\"))")
 
         tested_code = "import hello; hello.hello()"
         command = JBANG_CMD + [hello_java_file, tested_code]

--- a/integration-tests/test_jbang_integration.py
+++ b/integration-tests/test_jbang_integration.py
@@ -252,8 +252,8 @@ def hello():
                 f"//PIP termcolor==2.2\n//PYTHON_RESOURCES_DIRECTORY {resources_dir}")
         rd = resources_dir.replace("\\", "\\\\")
         util.replace_in_file(hello_java_file,
-                "GraalPyResources.of(VirtualFileSystem.create())",
-                f"GraalPyResources.of(java.nio.file.Path.of(\"{rd}\"))")
+                "GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create())",
+                f"GraalPyResources.forExternalDirectory(java.nio.file.Path.of(\"{rd}\"))")
 
         tested_code = "import hello; hello.hello()"
         command = JBANG_CMD + [hello_java_file, tested_code]

--- a/integration-tests/test_maven_plugin.py
+++ b/integration-tests/test_maven_plugin.py
@@ -437,8 +437,8 @@ class MavenPluginTest(util.BuildToolTestBase):
             util.replace_in_file(os.path.join(target_dir, "src", "main", "java", "it", "pkg", "GraalPy.java"),
                  f'VirtualFileSystem vfs = VirtualFileSystem.newBuilder().resourceDirectory("GRAALPY-VFS/archetype.it/{target_name}").build();', "")
             util.replace_in_file(os.path.join(target_dir, "src", "main", "java", "it", "pkg", "GraalPy.java"),
-                "GraalPyResources.of(vfs)",
-                "GraalPyResources.of(Path.of(\"" + (resources_dir if "win32" != sys.platform else resources_dir.replace("\\", "\\\\")) + "\"))")
+                "GraalPyResources.forVirtualFileSystem(vfs)",
+                "GraalPyResources.forExternalDirectory(Path.of(\"" + (resources_dir if "win32" != sys.platform else resources_dir.replace("\\", "\\\\")) + "\"))")
 
             # patch pom.xml
             util.replace_in_file(os.path.join(target_dir, "pom.xml"),
@@ -839,11 +839,11 @@ class MavenPluginTest(util.BuildToolTestBase):
                                     .build();
                             try (Context context1 = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
                                    .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                                   .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                                   .apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
                                    .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build();
                                  Context context2 = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
                                    .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                                   .apply(GraalPyResources.of(vfs))
+                                   .apply(GraalPyResources.forVirtualFileSystem(vfs))
                                    .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
                                 int index = 0;
                                 for (Context ctx: new Context[] {context1, context2}) {
@@ -1054,7 +1054,7 @@ class MavenPluginTest(util.BuildToolTestBase):
                                     .build();
                             String path1 = java.nio.file.Paths.get(vfs.getMountPoint(), "src", "app1.txt").toString();
                             String path2 = java.nio.file.Paths.get(vfs.getMountPoint(), "src", "app2.txt").toString();
-                            try (Context context = Context.newBuilder().apply(GraalPyResources.of(vfs)).build()) {
+                            try (Context context = Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(vfs)).build()) {
                                 context.eval("python", "def read_vfs_file(path): import os; print(open(path, 'r').read().strip())");
                                 var readVfsFile = context.getBindings("python").getMember("read_vfs_file");
                                 readVfsFile.execute(path1);

--- a/integration-tests/test_maven_plugin.py
+++ b/integration-tests/test_maven_plugin.py
@@ -437,8 +437,8 @@ class MavenPluginTest(util.BuildToolTestBase):
             util.replace_in_file(os.path.join(target_dir, "src", "main", "java", "it", "pkg", "GraalPy.java"),
                  f'VirtualFileSystem vfs = VirtualFileSystem.newBuilder().resourceDirectory("GRAALPY-VFS/archetype.it/{target_name}").build();', "")
             util.replace_in_file(os.path.join(target_dir, "src", "main", "java", "it", "pkg", "GraalPy.java"),
-                "GraalPyResources.contextBuilder(vfs).build()",
-                "GraalPyResources.contextBuilder(Path.of(\"" + (resources_dir if "win32" != sys.platform else resources_dir.replace("\\", "\\\\")) + "\")).build()")
+                "GraalPyResources.of(vfs)",
+                "GraalPyResources.of(Path.of(\"" + (resources_dir if "win32" != sys.platform else resources_dir.replace("\\", "\\\\")) + "\"))")
 
             # patch pom.xml
             util.replace_in_file(os.path.join(target_dir, "pom.xml"),
@@ -837,8 +837,14 @@ class MavenPluginTest(util.BuildToolTestBase):
                               org.graalvm.python.embedding.VirtualFileSystem.newBuilder()
                                     .resourceDirectory("GRAALPY-VFS/org.graalvm.python.tests/app1")
                                     .build();
-                            try (Context context1 = GraalPyResources.createContext();
-                                 Context context2 = GraalPyResources.contextBuilder(vfs).build()) {
+                            try (Context context1 = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
+                                   .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
+                                   .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                                   .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build();
+                                 Context context2 = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
+                                   .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
+                                   .apply(GraalPyResources.of(vfs))
+                                   .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
                                 int index = 0;
                                 for (Context ctx: new Context[] {context1, context2}) {
                                     ctx.eval("python", "import hello");
@@ -1048,7 +1054,7 @@ class MavenPluginTest(util.BuildToolTestBase):
                                     .build();
                             String path1 = java.nio.file.Paths.get(vfs.getMountPoint(), "src", "app1.txt").toString();
                             String path2 = java.nio.file.Paths.get(vfs.getMountPoint(), "src", "app2.txt").toString();
-                            try (Context context = GraalPyResources.contextBuilder(vfs).build()) {
+                            try (Context context = Context.newBuilder().apply(GraalPyResources.of(vfs)).build()) {
                                 context.eval("python", "def read_vfs_file(path): import os; print(open(path, 'r').read().strip())");
                                 var readVfsFile = context.getBindings("python").getMember("read_vfs_file");
                                 readVfsFile.execute(path1);

--- a/javainterfacegen/src/main/java/org/graalvm/python/javainterfacegen/ContextFactory.java
+++ b/javainterfacegen/src/main/java/org/graalvm/python/javainterfacegen/ContextFactory.java
@@ -42,6 +42,9 @@ package org.graalvm.python.javainterfacegen;
 
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.PolyglotAccess;
+import org.graalvm.polyglot.io.IOAccess;
 import org.graalvm.python.embedding.GraalPyResources;
 import org.graalvm.python.embedding.VirtualFileSystem;
 
@@ -54,7 +57,10 @@ public class ContextFactory {
 		if (context == null) {
 			VirtualFileSystem vfs = VirtualFileSystem.newBuilder()
 					.resourceDirectory("GRAALPY-VFS/org.graalvm.python/javainterfacegen").build();
-			context = GraalPyResources.contextBuilder(vfs)
+			context = Context.newBuilder().allowExperimentalOptions(false).allowAllAccess(false)
+					.allowHostAccess(HostAccess.ALL).allowCreateThread(true).allowNativeAccess(true)
+					.allowPolyglotAccess(PolyglotAccess.ALL).apply(GraalPyResources.of(vfs))
+					.extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true))
 					.engine(Engine.newBuilder("python").option("engine.WarnInterpreterOnly", "false").build()).build();
 		}
 		return context;

--- a/javainterfacegen/src/main/java/org/graalvm/python/javainterfacegen/ContextFactory.java
+++ b/javainterfacegen/src/main/java/org/graalvm/python/javainterfacegen/ContextFactory.java
@@ -59,7 +59,7 @@ public class ContextFactory {
 					.resourceDirectory("GRAALPY-VFS/org.graalvm.python/javainterfacegen").build();
 			context = Context.newBuilder().allowExperimentalOptions(false).allowAllAccess(false)
 					.allowHostAccess(HostAccess.ALL).allowCreateThread(true).allowNativeAccess(true)
-					.allowPolyglotAccess(PolyglotAccess.ALL).apply(GraalPyResources.of(vfs))
+					.allowPolyglotAccess(PolyglotAccess.ALL).apply(GraalPyResources.forVirtualFileSystem(vfs))
 					.extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true))
 					.engine(Engine.newBuilder("python").option("engine.WarnInterpreterOnly", "false").build()).build();
 		}

--- a/org.graalvm.python.embedding.tools/src/main/java/org/graalvm/python/embedding/tools/JavaToolchain.java
+++ b/org.graalvm.python.embedding.tools/src/main/java/org/graalvm/python/embedding/tools/JavaToolchain.java
@@ -65,22 +65,18 @@ public final class JavaToolchain {
 				parseJavaMajorVersion(System.getProperty("java.version")));
 	}
 
-	public static JavaToolchain fromJavaExecutable(Path javaExecutable, int javaMajorVersion) {
+	public static JavaToolchain fromJavaExecutableAndVersion(Path javaExecutable, int javaMajorVersion) {
 		if (javaExecutable == null) {
 			return fromSystemJava();
 		}
 		return new JavaToolchain(javaExecutable, javaMajorVersion);
 	}
 
-	public static JavaToolchain fromJavaExecutable(Path javaExecutable, String javaVersion) {
+	public static JavaToolchain fromJavaExecutable(Path javaExecutable) {
 		if (javaExecutable == null) {
 			return fromSystemJava();
 		}
-		int javaMajorVersion = parseJavaMajorVersion(javaVersion);
-		if (javaMajorVersion < 0) {
-			javaMajorVersion = javaMajorVersion(javaExecutable);
-		}
-		return fromJavaExecutable(javaExecutable, javaMajorVersion);
+		return fromJavaExecutableAndVersion(javaExecutable, javaMajorVersion(javaExecutable));
 	}
 
 	public Path javaExecutable() {

--- a/org.graalvm.python.embedding.tools/src/test/java/org/graalvm/python/embedding/tools/JavaToolchainTest.java
+++ b/org.graalvm.python.embedding.tools/src/test/java/org/graalvm/python/embedding/tools/JavaToolchainTest.java
@@ -64,16 +64,9 @@ public class JavaToolchainTest {
 	@Test
 	public void usesConfiguredJavaExecutableAndVersion() {
 		Path java = Path.of("custom-java-home", "bin", "java");
-		JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutable(java, 25);
+		JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutableAndVersion(java, 25);
 		assertEquals(java, javaToolchain.javaExecutable());
 		assertEquals(25, javaToolchain.javaMajorVersion());
-	}
-
-	@Test
-	public void parsesConfiguredJavaVersion() {
-		Path java = Path.of("custom-java-home", "bin", "java");
-		JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutable(java, "21.0.11");
-		assertEquals(21, javaToolchain.javaMajorVersion());
 	}
 
 	@Test
@@ -81,7 +74,7 @@ public class JavaToolchainTest {
 			throws IOException {
 		Files.writeString(fakeJavaHome.resolve("release"), "JAVA_VERSION=\"25.0.1\"\n");
 		Path java = fakeJavaHome.resolve("bin").resolve("java");
-		JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutable(java, (String) null);
+		JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutable(java);
 		assertEquals(java, javaToolchain.javaExecutable());
 		assertEquals(25, javaToolchain.javaMajorVersion());
 	}
@@ -92,7 +85,7 @@ public class JavaToolchainTest {
 		try {
 			System.setProperty("java.version", "25.0.1");
 			Path java = Path.of("custom-java-home", "bin", "java");
-			JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutable(java, (String) null);
+			JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutable(java);
 			assertEquals(java, javaToolchain.javaExecutable());
 			assertEquals(-1, javaToolchain.javaMajorVersion());
 		} finally {
@@ -105,7 +98,7 @@ public class JavaToolchainTest {
 		String originalJavaVersion = System.getProperty("java.version");
 		try {
 			System.setProperty("java.version", "25.0.1");
-			JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutable(null, "17");
+			JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutable(null);
 			assertEquals(Path.of(System.getProperty("java.home"), "bin", "java"), javaToolchain.javaExecutable());
 			assertEquals(25, javaToolchain.javaMajorVersion());
 		} finally {

--- a/org.graalvm.python.embedding.tools/src/test/java/org/graalvm/python/embedding/tools/exec/GraalPyRunnerTest.java
+++ b/org.graalvm.python.embedding.tools/src/test/java/org/graalvm/python/embedding/tools/exec/GraalPyRunnerTest.java
@@ -51,13 +51,16 @@ public class GraalPyRunnerTest {
 
 	@Test
 	public void detectsExtraOptionsFromConfiguredJavaVersion() {
-		assertArrayEquals(new String[]{"--sun-misc-unsafe-memory-access=allow"}, GraalPyRunner
-				.getExtraJavaOptions(JavaToolchain.fromJavaExecutable(Path.of("custom-java-home", "bin", "java"), 25)));
+		JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutableAndVersion(
+				Path.of("custom-java-home", "bin", "java"), 25);
+		assertArrayEquals(new String[]{"--sun-misc-unsafe-memory-access=allow"},
+				GraalPyRunner.getExtraJavaOptions(javaToolchain));
 	}
 
 	@Test
 	public void skipsExtraOptionsForOlderConfiguredJavaVersion() {
-		assertArrayEquals(new String[0], GraalPyRunner
-				.getExtraJavaOptions(JavaToolchain.fromJavaExecutable(Path.of("custom-java-home", "bin", "java"), 21)));
+		JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutableAndVersion(
+				Path.of("custom-java-home", "bin", "java"), 21);
+		assertArrayEquals(new String[0], GraalPyRunner.getExtraJavaOptions(javaToolchain));
 	}
 }

--- a/org.graalvm.python.embedding/pom.xml
+++ b/org.graalvm.python.embedding/pom.xml
@@ -123,6 +123,8 @@
             <configuration>
               <argLine>
                 --add-opens org.graalvm.truffle/com.oracle.truffle.polyglot=org.graalvm.python.embedding
+                --add-opens org.graalvm.polyglot/org.graalvm.polyglot=org.graalvm.python.embedding
+                --add-opens org.graalvm.polyglot/org.graalvm.polyglot.io=org.graalvm.python.embedding
               </argLine>
               <useModulePath>true</useModulePath>
             </configuration>
@@ -174,6 +176,10 @@
           <additionalJOptions>
             <additionalJOption>-Xdoclint:all</additionalJOption>
           </additionalJOptions>
+          <additionalOptions>
+            <additionalOption>--snippet-path</additionalOption>
+            <additionalOption>${project.basedir}/src/main/java</additionalOption>
+          </additionalOptions>
         </configuration>
         <executions>
           <execution>

--- a/org.graalvm.python.embedding/snapshot.sigtest
+++ b/org.graalvm.python.embedding/snapshot.sigtest
@@ -48,12 +48,19 @@ meth public java.lang.String toString()
 CLSS public abstract interface java.lang.constant.Constable
 meth public abstract java.util.Optional<? extends java.lang.constant.ConstantDesc> describeConstable()
 
+CLSS public abstract interface java.util.function.Consumer<%0 extends java.lang.Object>
+meth public abstract void accept({java.util.function.Consumer%0})
+
 CLSS public final org.graalvm.python.embedding.GraalPyResources
+meth public void accept(org.graalvm.polyglot.Context$Builder)
 meth public static java.nio.file.Path getNativeExecutablePath()
 meth public static org.graalvm.polyglot.Context createContext()
 meth public static org.graalvm.polyglot.Context$Builder contextBuilder()
 meth public static org.graalvm.polyglot.Context$Builder contextBuilder(java.nio.file.Path)
 meth public static org.graalvm.polyglot.Context$Builder contextBuilder(org.graalvm.python.embedding.VirtualFileSystem)
+meth public static org.graalvm.python.embedding.GraalPyResources of(java.nio.file.Path)
+meth public static org.graalvm.python.embedding.GraalPyResources of(org.graalvm.python.embedding.VirtualFileSystem)
+intf java.util.function.Consumer<org.graalvm.polyglot.Context$Builder>
 meth public static void extractVirtualFileSystemResources(org.graalvm.python.embedding.VirtualFileSystem,java.nio.file.Path) throws java.io.IOException
 supr java.lang.Object
 

--- a/org.graalvm.python.embedding/snapshot.sigtest
+++ b/org.graalvm.python.embedding/snapshot.sigtest
@@ -58,8 +58,8 @@ meth public static org.graalvm.polyglot.Context createContext()
 meth public static org.graalvm.polyglot.Context$Builder contextBuilder()
 meth public static org.graalvm.polyglot.Context$Builder contextBuilder(java.nio.file.Path)
 meth public static org.graalvm.polyglot.Context$Builder contextBuilder(org.graalvm.python.embedding.VirtualFileSystem)
-meth public static org.graalvm.python.embedding.GraalPyResources of(java.nio.file.Path)
-meth public static org.graalvm.python.embedding.GraalPyResources of(org.graalvm.python.embedding.VirtualFileSystem)
+meth public static org.graalvm.python.embedding.GraalPyResources forExternalDirectory(java.nio.file.Path)
+meth public static org.graalvm.python.embedding.GraalPyResources forVirtualFileSystem(org.graalvm.python.embedding.VirtualFileSystem)
 intf java.util.function.Consumer<org.graalvm.polyglot.Context$Builder>
 meth public static void extractVirtualFileSystemResources(org.graalvm.python.embedding.VirtualFileSystem,java.nio.file.Path) throws java.io.IOException
 supr java.lang.Object

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/GraalPyResources.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/GraalPyResources.java
@@ -53,6 +53,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * This class provides utilities related to Python resources used in GraalPy
@@ -118,7 +120,9 @@ import java.nio.file.Paths;
  * VirtualFileSystem.Builder builder = VirtualFileSystem.newBuilder();
  * builder.unixMountPoint("/python-resources");
  * VirtualFileSystem vfs = builder.build();
- * try (Context context = GraalPyResources.contextBuilder(vfs).build()) {
+ * try (Context context = Context.newBuilder()
+ * 		.apply(GraalPyResources.of(vfs))
+ * 		.build()) {
  * 	context.eval("python", "for line in open('/python-resources/data.txt').readlines(): print(line)");
  * } catch (PolyglotException e) {
  * 	if (e.isExit()) {
@@ -157,7 +161,9 @@ import java.nio.file.Paths;
  * external resource directory:
  *
  * <pre>
- * try (Context context = GraalPyResources.contextBuilder(Path.of("python-resources")).build()) {
+ * try (Context context = Context.newBuilder()
+ * 		.apply(GraalPyResources.of(Path.of("python-resources")))
+ * 		.build()) {
  * 	context.eval("python", "import mymodule; mymodule.print_hello_world()");
  * } catch (PolyglotException e) {
  * 	if (e.isExit()) {
@@ -188,9 +194,228 @@ import java.nio.file.Paths;
  *
  * @since 24.2.0
  */
-public final class GraalPyResources {
+public final class GraalPyResources implements Consumer<Context.Builder> {
+	private Consumer<Context.Builder> builderTemplate;
 
-	private GraalPyResources() {
+	private GraalPyResources(Consumer<Context.Builder> builderTemplate) {
+		this.builderTemplate = Objects.requireNonNull(builderTemplate);
+	}
+
+	/**
+	 * Creates a GraalPy resource configuration for the given
+	 * {@link VirtualFileSystem}. The configuration is applied to an existing
+	 * {@link Context.Builder} and sets the VFS filesystem and Python resource
+	 * options for the <a href="https://docs.python.org/3/library/venv.html">Python
+	 * virtual environment</a> contained in the virtual filesystem.
+	 * <p>
+	 * Following resource paths are preconfigured:
+	 * <ul>
+	 * <li><code>/org.graalvm.python.vfs/venv</code> - is set as the python virtual
+	 * environment location</li>
+	 * <li><code>/org.graalvm.python.vfs/src</code> - is set as the python sources
+	 * location</li>
+	 * </ul>
+	 * <p>
+	 * <b>Example</b> creating a GraalPy context and additionally setting the
+	 * verbose option and allowing host interop.
+	 *
+	 * <pre>
+	 * VirtualFileSystem vfs = VirtualFileSystem.create();
+	 * Context.Builder builder = Context.newBuilder()
+	 * 		.apply(GraalPyResources.of(vfs))
+	 * 		.option("python.VerboseFlag", "true")
+	 * 		.allowHostAccess(HostAccess.ALL);
+	 * try (Context context = builder.build()) {
+	 * 	context.eval("python", "print('hello world')");
+	 * } catch (PolyglotException e) {
+	 * 	if (e.isExit()) {
+	 * 		System.exit(e.getExitStatus());
+	 * 	} else {
+	 * 		throw e;
+	 * 	}
+	 * }
+	 * </pre>
+	 * <p>
+	 * When the virtual filesystem is located in other than the default resource
+	 * directory, {@code org.graalvm.python.vfs}, i.e., using Maven or Gradle option
+	 * {@code resourceDirectory}, configure it with
+	 * {@link VirtualFileSystem.Builder#resourceDirectory(String)} when building the
+	 * {@link VirtualFileSystem} passed to this method.
+	 *
+	 * <p>
+	 * <b>Full details: </b> this method applies the following options to the given
+	 * {@link Context.Builder}:
+	 *
+	 * <pre>
+	 *     .extendIO(IOAccess.NONE, ioBuilder -> configureVirtualFileSystem())
+	 *     .option("python.ForceImportSite", "true") // allows importing packages from the VFS
+	 *     .option("python.PosixModuleBackend", "java")
+	 *     .option("python.DontWriteBytecodeFlag", "true")
+	 *     .option("python.CheckHashPycsMode", "never")
+	 *     .option("python.Executable", appropriatePathWithinVirtualFileSystem())
+	 *     .option("python.PythonPath", appropriatePathWithinVirtualFileSystem())
+	 *     .option("python.InputFilePath", appropriatePathWithinVirtualFileSystem());
+	 * </pre>
+	 *
+	 * @param vfs
+	 *            the {@link VirtualFileSystem} to configure on the target
+	 *            {@link Context.Builder}
+	 * @see <a href=
+	 *      "https://github.com/oracle/graalpython/blob/master/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/PythonOptions.java">PythonOptions</a>
+	 * @return a {@link GraalPyResources} configuring a
+	 *         {@link org.graalvm.polyglot.Context.Builder}
+	 * @since 25.1.0
+	 */
+	public static GraalPyResources of(VirtualFileSystem vfs) {
+		return new GraalPyResources(builder -> applyVirtualFilesystemConfig(builder, vfs));
+	}
+
+	/**
+	 * Creates a GraalPy resource configuration for resources located in an external
+	 * directory in the real filesystem. The configuration is applied to an existing
+	 * {@link Context.Builder} and sets host filesystem IO plus Python resource path
+	 * options.
+	 * <p>
+	 * Following resource paths are preconfigured:
+	 * <ul>
+	 * <li><code>${externalResourcesDirectory}/venv</code> - is set as the python
+	 * environment location</li>
+	 * <li><code>${externalResourcesDirectory}/src</code> - is set as the python
+	 * sources location</li>
+	 * </ul>
+	 * <p>
+	 * <b>Example</b> creating a GraalPy context and additionally setting the
+	 * verbose option and allowing host interop.
+	 *
+	 * <pre>
+	 * Context.Builder builder = Context.newBuilder()
+	 * 		.apply(GraalPyResources.of(Path.of("python-resources")))
+	 * 		.option("python.VerboseFlag", "true")
+	 * 		.allowHostAccess(HostAccess.ALL);
+	 * try (Context context = builder.build()) {
+	 * 	context.eval("python", "import mymodule; mymodule.print_hello_world()");
+	 * } catch (PolyglotException e) {
+	 * 	if (e.isExit()) {
+	 * 		System.exit(e.getExitStatus());
+	 * 	} else {
+	 * 		throw e;
+	 * 	}
+	 * }
+	 * </pre>
+	 *
+	 * In this example we:
+	 * <ul>
+	 * <li>create a GraalPy context which is preconfigured with GraalPy resources in
+	 * an external resource directory</li>
+	 * <li>use the context to import the python module <code>mymodule</code>, which
+	 * should be either located in <code>python-resources/src</code> or in a python
+	 * package installed in <code>/python/venv</code> (python virtual
+	 * environment)</li>
+	 * <li>note that in this scenario, the Python context has access to the
+	 * extracted resources as well as the rest of the real filesystem</li>
+	 * </ul>
+	 *
+	 * <p>
+	 * External resources directory is often used for better compatibility with
+	 * Python native extensions that may bypass the Python abstractions and access
+	 * the filesystem directly from native code. Setting the
+	 * {@code PosixModuleBackend} option to "native" increases the compatibility
+	 * further, but in such case even Python code bypasses the Truffle abstractions
+	 * and accesses native POSIX APIs directly. Usage:
+	 *
+	 * <pre>
+	 * Context.newBuilder()
+	 * 		.apply(GraalPyResources.of(Path.of("python-resources")))
+	 * 		.option("python.PosixModuleBackend", "native")
+	 * </pre>
+	 * <p>
+	 *
+	 * When Maven or Gradle GraalPy plugin is used to build the virtual environment,
+	 * it also has to be configured to generate the virtual environment into the
+	 * same directory using the {@code <externalDirectory>} tag in Maven or the
+	 * {@code externalDirectory} field in Gradle.
+	 *
+	 * <p>
+	 * <b>Full details: </b> this method applies the following options to the given
+	 * {@link Context.Builder}:
+	 *
+	 * <pre>
+	 *     .extendIO(IOAccess.NONE, ioBuilder -> ioBuilder.allowHostFileAccess(true))
+	 *     .option("python.ForceImportSite", "true") // allows importing packages from the virtual environment
+	 *     .option("python.Executable", appropriatePathWithinExternalDirectory())
+	 *     .option("python.PythonPath", appropriatePathWithinExternalDirectory())
+	 *     .option("python.InputFilePath", appropriatePathWithinExternalDirectory());
+	 * </pre>
+	 *
+	 * @param externalResourcesDirectory
+	 *            the root directory with GraalPy specific embedding resources
+	 * @return a {@link GraalPyResources} configuring a
+	 *         {@link org.graalvm.polyglot.Context.Builder}
+	 * @since 25.1.0
+	 */
+	public static GraalPyResources of(Path externalResourcesDirectory) {
+		return new GraalPyResources(builder -> applyExternalDirectoryConfig(builder, externalResourcesDirectory));
+	}
+
+	@Override
+	public void accept(Context.Builder builder) {
+		builderTemplate.accept(builder);
+	}
+
+	// Options shared by both VirtualFileSystem and external resources directory
+	// use-case
+	private static Context.Builder applySharedContextConfig(Context.Builder builder) {
+		return builder.
+		// Force to automatically import site.py module, to make Python packages
+		// available
+				option("python.ForceImportSite", "true");
+	}
+
+	private static void applyVirtualFilesystemConfig(Context.Builder builder, VirtualFileSystem vfs) {
+		applySharedContextConfig(builder).
+		// allow access to the virtual filesystem and preserve any existing IO settings
+				extendIO(IOAccess.NONE, ioBuilder -> ioBuilder.fileSystem(vfs.delegatingFileSystem)).
+				// choose the backend for the POSIX module
+				option("python.PosixModuleBackend", "java").
+				// equivalent to the Python -B flag
+				option("python.DontWriteBytecodeFlag", "true").
+				// The sys.executable path, a virtual path that is used by the interpreter
+				// to discover packages
+				option("python.Executable", vfs.impl.vfsVenvPath()
+						+ (VirtualFileSystemImpl.isWindows() ? "\\Scripts\\python.exe" : "/bin/python"))
+				.
+				// Set python path to point to sources stored in
+				// src/main/resources/org.graalvm.python.vfs/src
+				option("python.PythonPath", vfs.impl.vfsSrcPath()).
+				// pass the path to be executed
+				option("python.InputFilePath", vfs.impl.vfsSrcPath()).
+				// causes the interpreter to always assume hash-based pycs are valid
+				option("python.CheckHashPycsMode", "never");
+	}
+
+	private static void applyExternalDirectoryConfig(Context.Builder builder, Path externalResourcesDirectory) {
+		String execPath;
+		if (VirtualFileSystemImpl.isWindows()) {
+			execPath = externalResourcesDirectory.resolve(VirtualFileSystemImpl.VFS_VENV).resolve("Scripts")
+					.resolve("python.exe").toAbsolutePath().toString();
+		} else {
+			execPath = externalResourcesDirectory.resolve(VirtualFileSystemImpl.VFS_VENV).resolve("bin")
+					.resolve("python").toAbsolutePath().toString();
+		}
+
+		String srcPath = externalResourcesDirectory.resolve(VirtualFileSystemImpl.VFS_SRC).toAbsolutePath().toString();
+		applySharedContextConfig(builder).
+		// allow host file access needed by external resources; callers can restrict
+		// this by extending IO after applying the resource configuration
+				extendIO(IOAccess.NONE, ioBuilder -> ioBuilder.allowHostFileAccess(true)).
+				// The sys.executable path, a virtual path that is used by the interpreter
+				// to discover packages
+				option("python.Executable", execPath).
+				// Set python path to point to sources stored in
+				// src/main/resources/org.graalvm.python.vfs/src
+				option("python.PythonPath", srcPath).
+				// pass the path to be executed
+				option("python.InputFilePath", srcPath);
 	}
 
 	/**
@@ -215,7 +440,25 @@ public final class GraalPyResources {
 	 *
 	 * @return a new {@link Context} instance
 	 * @since 24.2.0
+	 * @deprecated use
+	 *             <code>Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create())).build()</code>.
+	 *             Unlike this method, {@link #of(VirtualFileSystem)} is a
+	 *             {@link Consumer} for {@link Context.Builder#apply(Consumer)}. It
+	 *             configures <em>only</em> Context options relevant for GraalPy
+	 *             resource integration for the default {@link VirtualFileSystem} on
+	 *             an existing builder.
+	 *             <p>
+	 *             Starting from a fresh builder, the following code reproduces the
+	 *             complete behavior of deprecated {@link #createContext()} while
+	 *             using the new API:
+	 *             </p>
+	 *
+	 *             {@snippet class =
+	 *             "org.graalvm.python.embedding.GraalPyResourcesMigrationSnippets"
+	 *             region = "default-virtual-filesystem-context-builder"}
+	 *             Call {@code builder.build()} to create the {@link Context}.
 	 */
+	@Deprecated(since = "25.1.0")
 	public static Context createContext() {
 		return contextBuilder().build();
 	}
@@ -260,7 +503,24 @@ public final class GraalPyResources {
 	 *      "https://github.com/oracle/graalpython/blob/master/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/runtime/PythonOptions.java">PythonOptions</a>
 	 * @return a new {@link org.graalvm.polyglot.Context.Builder} instance
 	 * @since 24.2.0
+	 * @deprecated use
+	 *             <code>Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create()))</code>.
+	 *             Unlike this method, {@link #of(VirtualFileSystem)} is a
+	 *             {@link Consumer} for {@link Context.Builder#apply(Consumer)}. It
+	 *             configures <em>only</em> Context options relevant for GraalPy
+	 *             resource integration for the default {@link VirtualFileSystem} on
+	 *             an existing builder.
+	 *             <p>
+	 *             Starting from a fresh builder, the following code reproduces the
+	 *             complete behavior of deprecated {@link #contextBuilder()} while
+	 *             using the new API:
+	 *             </p>
+	 *
+	 *             {@snippet class =
+	 *             "org.graalvm.python.embedding.GraalPyResourcesMigrationSnippets"
+	 *             region = "default-virtual-filesystem-context-builder"}
 	 */
+	@Deprecated(since = "25.1.0")
 	public static Context.Builder contextBuilder() {
 		VirtualFileSystem vfs = VirtualFileSystem.create();
 		return contextBuilder(vfs);
@@ -317,7 +577,25 @@ public final class GraalPyResources {
 	 * @see VirtualFileSystem.Builder
 	 *
 	 * @since 24.2.0
+	 * @deprecated use
+	 *             <code>Context.newBuilder().apply(GraalPyResources.of(vfs))</code>.
+	 *             Unlike this method, {@link #of(VirtualFileSystem)} is a
+	 *             {@link Consumer} for {@link Context.Builder#apply(Consumer)}. It
+	 *             configures <em>only</em> Context options relevant for GraalPy
+	 *             resource integration for the given {@link VirtualFileSystem} on
+	 *             an existing builder.
+	 *             <p>
+	 *             Starting from a fresh builder, the following code reproduces the
+	 *             complete behavior of deprecated
+	 *             {@link #contextBuilder(VirtualFileSystem)} while using the new
+	 *             API:
+	 *             </p>
+	 *
+	 *             {@snippet class =
+	 *             "org.graalvm.python.embedding.GraalPyResourcesMigrationSnippets"
+	 *             region = "virtual-filesystem-context-builder"}
 	 */
+	@Deprecated(since = "25.1.0")
 	public static Context.Builder contextBuilder(VirtualFileSystem vfs) {
 		return createContextBuilder().
 		// allow access to the virtual and the host filesystem, as well as sockets
@@ -398,7 +676,24 @@ public final class GraalPyResources {
 	 *            the root directory with GraalPy specific embedding resources
 	 * @return a new {@link org.graalvm.polyglot.Context.Builder} instance
 	 * @since 24.2.0
+	 * @deprecated use
+	 *             <code>Context.newBuilder().apply(GraalPyResources.of(externalResourcesDirectory))</code>.
+	 *             Unlike this method, {@link #of(Path)} is a {@link Consumer} for
+	 *             {@link Context.Builder#apply(Consumer)}. It configures
+	 *             <em>only</em> Context options relevant for GraalPy resource
+	 *             integration for an external resource directory on an existing
+	 *             Context builder.
+	 *             <p>
+	 *             Starting from a fresh builder, the following code reproduces the
+	 *             complete behavior of deprecated {@link #contextBuilder(Path)}
+	 *             while using the new API:
+	 *             </p>
+	 *
+	 *             {@snippet class =
+	 *             "org.graalvm.python.embedding.GraalPyResourcesMigrationSnippets"
+	 *             region = "external-directory-context-builder"}
 	 */
+	@Deprecated(since = "25.1.0")
 	public static Context.Builder contextBuilder(Path externalResourcesDirectory) {
 		String execPath;
 		if (VirtualFileSystemImpl.isWindows()) {
@@ -455,15 +750,19 @@ public final class GraalPyResources {
 	 * resource directory located next to a native image executable.
 	 *
 	 * <pre>
-	 * Path resourcesDir = GraalPyResources.getNativeExecutablePath().getParent().resolve("python-resources");
-	 * try (Context context = GraalPyResources.contextBuilder(resourcesDir).build()) {
+	 * Path resourcesDir = GraalPyResources.getNativeExecutablePath()
+	 * 		.getParent()
+	 * 		.resolve("python-resources");
+	 * try (Context context = Context.newBuilder()
+	 * 		.apply(GraalPyResources.of(resourcesDir))
+	 * 		.build()) {
 	 * 	context.eval("python", "print('hello world')");
 	 * }
 	 * </pre>
 	 *
 	 * @return the native executable path if it could be retrieved, otherwise
 	 *         <code>null</code>.
-	 * @see #contextBuilder(Path)
+	 * @see #of(Path)
 	 *
 	 * @since 24.2.0
 	 */
@@ -501,9 +800,11 @@ public final class GraalPyResources {
 	 *
 	 * <pre>
 	 * Path resourcesDir = Path.of(System.getProperty("user.home"), ".cache", "my.java.python.app.resources");
-	 * VirtualFileSystem vfs = VirtualFileSystem.newBuilder().build();
+	 * VirtualFileSystem vfs = VirtualFileSystem.create();
 	 * GraalPyResources.extractVirtualFileSystemResources(vfs, resourcesDir);
-	 * try (Context context = GraalPyResources.contextBuilder(resourcesDir).build()) {
+	 * try (Context context = Context.newBuilder()
+	 * 		.apply(GraalPyResources.of(resourcesDir))
+	 * 		.build()) {
 	 * 	context.eval("python", "print('hello world')");
 	 * }
 	 * </pre>
@@ -515,7 +816,7 @@ public final class GraalPyResources {
 	 *            the target directory to extract the resources to
 	 * @throws IOException
 	 *             if resources isn't a directory
-	 * @see #contextBuilder(Path)
+	 * @see #of(Path)
 	 * @see VirtualFileSystem.Builder#resourceLoadingClass(Class)
 	 *
 	 * @since 24.2.0

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/GraalPyResources.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/GraalPyResources.java
@@ -121,7 +121,7 @@ import java.util.function.Consumer;
  * builder.unixMountPoint("/python-resources");
  * VirtualFileSystem vfs = builder.build();
  * try (Context context = Context.newBuilder()
- * 		.apply(GraalPyResources.of(vfs))
+ * 		.apply(GraalPyResources.forVirtualFileSystem(vfs))
  * 		.build()) {
  * 	context.eval("python", "for line in open('/python-resources/data.txt').readlines(): print(line)");
  * } catch (PolyglotException e) {
@@ -162,7 +162,7 @@ import java.util.function.Consumer;
  *
  * <pre>
  * try (Context context = Context.newBuilder()
- * 		.apply(GraalPyResources.of(Path.of("python-resources")))
+ * 		.apply(GraalPyResources.forExternalDirectory(Path.of("python-resources")))
  * 		.build()) {
  * 	context.eval("python", "import mymodule; mymodule.print_hello_world()");
  * } catch (PolyglotException e) {
@@ -222,7 +222,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 * <pre>
 	 * VirtualFileSystem vfs = VirtualFileSystem.create();
 	 * Context.Builder builder = Context.newBuilder()
-	 * 		.apply(GraalPyResources.of(vfs))
+	 * 		.apply(GraalPyResources.forVirtualFileSystem(vfs))
 	 * 		.option("python.VerboseFlag", "true")
 	 * 		.allowHostAccess(HostAccess.ALL);
 	 * try (Context context = builder.build()) {
@@ -266,7 +266,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 *         {@link org.graalvm.polyglot.Context.Builder}
 	 * @since 25.1.0
 	 */
-	public static GraalPyResources of(VirtualFileSystem vfs) {
+	public static GraalPyResources forVirtualFileSystem(VirtualFileSystem vfs) {
 		return new GraalPyResources(builder -> applyVirtualFilesystemConfig(builder, vfs));
 	}
 
@@ -289,7 +289,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 *
 	 * <pre>
 	 * Context.Builder builder = Context.newBuilder()
-	 * 		.apply(GraalPyResources.of(Path.of("python-resources")))
+	 * 		.apply(GraalPyResources.forExternalDirectory(Path.of("python-resources")))
 	 * 		.option("python.VerboseFlag", "true")
 	 * 		.allowHostAccess(HostAccess.ALL);
 	 * try (Context context = builder.build()) {
@@ -325,7 +325,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 *
 	 * <pre>
 	 * Context.newBuilder()
-	 * 		.apply(GraalPyResources.of(Path.of("python-resources")))
+	 * 		.apply(GraalPyResources.forExternalDirectory(Path.of("python-resources")))
 	 * 		.option("python.PosixModuleBackend", "native")
 	 * </pre>
 	 * <p>
@@ -353,7 +353,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 *         {@link org.graalvm.polyglot.Context.Builder}
 	 * @since 25.1.0
 	 */
-	public static GraalPyResources of(Path externalResourcesDirectory) {
+	public static GraalPyResources forExternalDirectory(Path externalResourcesDirectory) {
 		return new GraalPyResources(builder -> applyExternalDirectoryConfig(builder, externalResourcesDirectory));
 	}
 
@@ -441,8 +441,9 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 * @return a new {@link Context} instance
 	 * @since 24.2.0
 	 * @deprecated use
-	 *             <code>Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create())).build()</code>.
-	 *             Unlike this method, {@link #of(VirtualFileSystem)} is a
+	 *             <code>Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create())).build()</code>.
+	 *             Unlike this method,
+	 *             {@link #forVirtualFileSystem(VirtualFileSystem)} is a
 	 *             {@link Consumer} for {@link Context.Builder#apply(Consumer)}. It
 	 *             configures <em>only</em> Context options relevant for GraalPy
 	 *             resource integration for the default {@link VirtualFileSystem} on
@@ -504,8 +505,9 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 * @return a new {@link org.graalvm.polyglot.Context.Builder} instance
 	 * @since 24.2.0
 	 * @deprecated use
-	 *             <code>Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create()))</code>.
-	 *             Unlike this method, {@link #of(VirtualFileSystem)} is a
+	 *             <code>Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))</code>.
+	 *             Unlike this method,
+	 *             {@link #forVirtualFileSystem(VirtualFileSystem)} is a
 	 *             {@link Consumer} for {@link Context.Builder#apply(Consumer)}. It
 	 *             configures <em>only</em> Context options relevant for GraalPy
 	 *             resource integration for the default {@link VirtualFileSystem} on
@@ -578,8 +580,9 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 *
 	 * @since 24.2.0
 	 * @deprecated use
-	 *             <code>Context.newBuilder().apply(GraalPyResources.of(vfs))</code>.
-	 *             Unlike this method, {@link #of(VirtualFileSystem)} is a
+	 *             <code>Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(vfs))</code>.
+	 *             Unlike this method,
+	 *             {@link #forVirtualFileSystem(VirtualFileSystem)} is a
 	 *             {@link Consumer} for {@link Context.Builder#apply(Consumer)}. It
 	 *             configures <em>only</em> Context options relevant for GraalPy
 	 *             resource integration for the given {@link VirtualFileSystem} on
@@ -677,12 +680,12 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 * @return a new {@link org.graalvm.polyglot.Context.Builder} instance
 	 * @since 24.2.0
 	 * @deprecated use
-	 *             <code>Context.newBuilder().apply(GraalPyResources.of(externalResourcesDirectory))</code>.
-	 *             Unlike this method, {@link #of(Path)} is a {@link Consumer} for
-	 *             {@link Context.Builder#apply(Consumer)}. It configures
-	 *             <em>only</em> Context options relevant for GraalPy resource
-	 *             integration for an external resource directory on an existing
-	 *             Context builder.
+	 *             <code>Context.newBuilder().apply(GraalPyResources.forExternalDirectory(externalResourcesDirectory))</code>.
+	 *             Unlike this method, {@link #forExternalDirectory(Path)} is a
+	 *             {@link Consumer} for {@link Context.Builder#apply(Consumer)}. It
+	 *             configures <em>only</em> Context options relevant for GraalPy
+	 *             resource integration for an external resource directory on an
+	 *             existing Context builder.
 	 *             <p>
 	 *             Starting from a fresh builder, the following code reproduces the
 	 *             complete behavior of deprecated {@link #contextBuilder(Path)}
@@ -754,7 +757,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 * 		.getParent()
 	 * 		.resolve("python-resources");
 	 * try (Context context = Context.newBuilder()
-	 * 		.apply(GraalPyResources.of(resourcesDir))
+	 * 		.apply(GraalPyResources.forExternalDirectory(resourcesDir))
 	 * 		.build()) {
 	 * 	context.eval("python", "print('hello world')");
 	 * }
@@ -762,7 +765,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 *
 	 * @return the native executable path if it could be retrieved, otherwise
 	 *         <code>null</code>.
-	 * @see #of(Path)
+	 * @see #forExternalDirectory(Path)
 	 *
 	 * @since 24.2.0
 	 */
@@ -803,7 +806,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 * VirtualFileSystem vfs = VirtualFileSystem.create();
 	 * GraalPyResources.extractVirtualFileSystemResources(vfs, resourcesDir);
 	 * try (Context context = Context.newBuilder()
-	 * 		.apply(GraalPyResources.of(resourcesDir))
+	 * 		.apply(GraalPyResources.forExternalDirectory(resourcesDir))
 	 * 		.build()) {
 	 * 	context.eval("python", "print('hello world')");
 	 * }
@@ -816,7 +819,7 @@ public final class GraalPyResources implements Consumer<Context.Builder> {
 	 *            the target directory to extract the resources to
 	 * @throws IOException
 	 *             if resources isn't a directory
-	 * @see #of(Path)
+	 * @see #forExternalDirectory(Path)
 	 * @see VirtualFileSystem.Builder#resourceLoadingClass(Class)
 	 *
 	 * @since 24.2.0

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/GraalPyResourcesMigrationSnippets.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/GraalPyResourcesMigrationSnippets.java
@@ -61,7 +61,7 @@ final class GraalPyResourcesMigrationSnippets {
 				.allowCreateThread(true)
 				.allowNativeAccess(true)
 				.allowPolyglotAccess(PolyglotAccess.ALL)
-				.apply(GraalPyResources.of(VirtualFileSystem.create()))
+				.apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
 				.extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true));
 		// @end
 		return builder;
@@ -76,7 +76,7 @@ final class GraalPyResourcesMigrationSnippets {
 				.allowCreateThread(true)
 				.allowNativeAccess(true)
 				.allowPolyglotAccess(PolyglotAccess.ALL)
-				.apply(GraalPyResources.of(vfs))
+				.apply(GraalPyResources.forVirtualFileSystem(vfs))
 				.extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true));
 		// @end
 		return builder;
@@ -90,7 +90,7 @@ final class GraalPyResourcesMigrationSnippets {
 				.allowCreateThread(true)
 				.allowNativeAccess(true)
 				.allowPolyglotAccess(PolyglotAccess.ALL)
-				.apply(GraalPyResources.of(externalResourcesDirectory))
+				.apply(GraalPyResources.forExternalDirectory(externalResourcesDirectory))
 				.allowHostAccess(HostAccess.ALL)
 				.allowIO(IOAccess.ALL).option("python.PosixModuleBackend", "java")
 				.option("python.DontWriteBytecodeFlag", "true");

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/GraalPyResourcesMigrationSnippets.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/GraalPyResourcesMigrationSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -38,50 +38,63 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.example;
+
+package org.graalvm.python.embedding;
 
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.PolyglotAccess;
-import org.graalvm.polyglot.PolyglotException;
-import org.graalvm.polyglot.Source;
-import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
-import java.io.IOException;
 
-import org.graalvm.python.embedding.GraalPyResources;
-import org.graalvm.python.embedding.VirtualFileSystem;
+import java.nio.file.Path;
 
-public class GraalPy {
-    private static final String PYTHON = "python";
+final class GraalPyResourcesMigrationSnippets {
+	private GraalPyResourcesMigrationSnippets() {
+	}
 
-    public static void main(String[] args) {
-        try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
-                .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                .apply(GraalPyResources.of(VirtualFileSystem.create()))
-                .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
-            Source source;
-            try {
-                source = Source.newBuilder(PYTHON, "import hello", "<internal>").internal(true).build();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+	static Context.Builder defaultVirtualFilesystemContextBuilder() {
+		// @start region = "default-virtual-filesystem-context-builder"
+		Context.Builder builder = Context.newBuilder()
+				.allowExperimentalOptions(false)
+				.allowAllAccess(false)
+				.allowHostAccess(HostAccess.ALL)
+				.allowCreateThread(true)
+				.allowNativeAccess(true)
+				.allowPolyglotAccess(PolyglotAccess.ALL)
+				.apply(GraalPyResources.of(VirtualFileSystem.create()))
+				.extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true));
+		// @end
+		return builder;
+	}
 
-            context.eval(source);
+	static Context.Builder virtualFilesystemContextBuilder(VirtualFileSystem vfs) {
+		// @start region = "virtual-filesystem-context-builder"
+		Context.Builder builder = Context.newBuilder()
+				.allowExperimentalOptions(false)
+				.allowAllAccess(false)
+				.allowHostAccess(HostAccess.ALL)
+				.allowCreateThread(true)
+				.allowNativeAccess(true)
+				.allowPolyglotAccess(PolyglotAccess.ALL)
+				.apply(GraalPyResources.of(vfs))
+				.extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true));
+		// @end
+		return builder;
+	}
 
-            // retrieve the python PyHello class
-            Value pyHelloClass = context.getPolyglotBindings().getMember("PyHello");
-            Value pyHello = pyHelloClass.newInstance();
-            // and cast it to the Hello interface which matches PyHello
-            Hello hello = pyHello.as(Hello.class);
-            hello.hello("java");
-
-        } catch (PolyglotException e) {
-            if (e.isExit()) {
-                System.exit(e.getExitStatus());
-            } else {
-                throw e;
-            }
-        }
-    }
+	static Context.Builder externalDirectoryContextBuilder(Path externalResourcesDirectory) {
+		// @start region = "external-directory-context-builder"
+		Context.Builder builder = Context.newBuilder()
+				.allowExperimentalOptions(false)
+				.allowAllAccess(false)
+				.allowCreateThread(true)
+				.allowNativeAccess(true)
+				.allowPolyglotAccess(PolyglotAccess.ALL)
+				.apply(GraalPyResources.of(externalResourcesDirectory))
+				.allowHostAccess(HostAccess.ALL)
+				.allowIO(IOAccess.ALL).option("python.PosixModuleBackend", "java")
+				.option("python.DontWriteBytecodeFlag", "true");
+		// @end
+		return builder;
+	}
 }

--- a/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/GraalPyResourcesMigrationTest.java
+++ b/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/GraalPyResourcesMigrationTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.graalvm.python.embedding.test;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.io.IOAccess;
+import org.graalvm.python.embedding.GraalPyResources;
+import org.graalvm.python.embedding.VirtualFileSystem;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GraalPyResourcesMigrationTest {
+	private static final String MIGRATION_SNIPPETS_CLASS = "org.graalvm.python.embedding.GraalPyResourcesMigrationSnippets";
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void createContextMigrationMatchesDeprecatedContextBuilderBeforeBuild() throws Exception {
+		assertBuilderConfigEquals(GraalPyResources.contextBuilder(), documentedDefaultVirtualFilesystemMigration());
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void defaultVirtualFilesystemMigrationMatchesDeprecatedContextBuilder() throws Exception {
+		assertBuilderConfigEquals(GraalPyResources.contextBuilder(), documentedDefaultVirtualFilesystemMigration());
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void virtualFilesystemMigrationMatchesDeprecatedContextBuilder() throws Exception {
+		try (VirtualFileSystem vfs = VirtualFileSystem.create()) {
+			assertBuilderConfigEquals(GraalPyResources.contextBuilder(vfs), documentedVirtualFilesystemMigration(vfs));
+		}
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void externalDirectoryMigrationMatchesDeprecatedContextBuilder() throws Exception {
+		Path externalResourcesDirectory = Files.createTempDirectory("graalpy-resources-migration");
+		assertBuilderConfigEquals(GraalPyResources.contextBuilder(externalResourcesDirectory),
+				documentedExternalDirectoryMigration(externalResourcesDirectory));
+	}
+
+	private static Context.Builder documentedDefaultVirtualFilesystemMigration() throws Exception {
+		return invokeMigrationSnippet("defaultVirtualFilesystemContextBuilder");
+	}
+
+	private static Context.Builder documentedVirtualFilesystemMigration(VirtualFileSystem vfs) throws Exception {
+		return invokeMigrationSnippet("virtualFilesystemContextBuilder", new Class<?>[]{VirtualFileSystem.class}, vfs);
+	}
+
+	private static Context.Builder documentedExternalDirectoryMigration(Path externalResourcesDirectory)
+			throws Exception {
+		return invokeMigrationSnippet("externalDirectoryContextBuilder", new Class<?>[]{Path.class},
+				externalResourcesDirectory);
+	}
+
+	private static Context.Builder invokeMigrationSnippet(String methodName) throws Exception {
+		return invokeMigrationSnippet(methodName, new Class<?>[0]);
+	}
+
+	private static Context.Builder invokeMigrationSnippet(String methodName, Class<?>[] parameterTypes, Object... args)
+			throws Exception {
+		Class<?> snippetsClass = Class.forName(MIGRATION_SNIPPETS_CLASS);
+		Method method = snippetsClass.getDeclaredMethod(methodName, parameterTypes);
+		method.setAccessible(true);
+		return (Context.Builder) method.invoke(null, args);
+	}
+
+	private static void assertBuilderConfigEquals(Context.Builder expected, Context.Builder actual) throws Exception {
+		assertEquals(builderConfig(expected), builderConfig(actual));
+	}
+
+	private static Map<String, Object> builderConfig(Context.Builder builder) throws Exception {
+		Map<String, Object> result = new LinkedHashMap<>();
+		for (Field field : Context.Builder.class.getDeclaredFields()) {
+			if (Modifier.isStatic(field.getModifiers()) || field.getName().equals("this$0")) {
+				continue;
+			}
+			field.setAccessible(true);
+			result.put(field.getName(), normalizeValue(field.get(builder)));
+		}
+		return result;
+	}
+
+	private static Object normalizeValue(Object value) throws Exception {
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof IOAccess ioAccess) {
+			return ioAccessConfig(ioAccess);
+		}
+		Class<?> valueClass = value.getClass();
+		if (valueClass.isArray()) {
+			int length = Array.getLength(value);
+			Object[] values = new Object[length];
+			for (int i = 0; i < length; i++) {
+				values[i] = normalizeValue(Array.get(value, i));
+			}
+			return Arrays.asList(values);
+		}
+		return value;
+	}
+
+	private static Map<String, Object> ioAccessConfig(IOAccess ioAccess) throws Exception {
+		Map<String, Object> result = new LinkedHashMap<>();
+		for (String fieldName : new String[]{"allowHostFileAccess", "allowHostSocketAccess", "fileSystem"}) {
+			Field field = IOAccess.class.getDeclaredField(fieldName);
+			field.setAccessible(true);
+			Object value = field.get(ioAccess);
+			if (fieldName.equals("fileSystem")) {
+				// Default-VFS migration paths create equivalent but distinct FileSystem
+				// instances.
+				result.put(fieldName, value == null ? null : value.getClass().getName());
+			} else {
+				result.put(fieldName, value);
+			}
+		}
+		return result;
+	}
+}

--- a/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/integration/GraalPyResourcesTests.java
+++ b/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/integration/GraalPyResourcesTests.java
@@ -40,22 +40,142 @@
  */
 package org.graalvm.python.embedding.test.integration;
 
+import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.python.embedding.GraalPyResources;
 import org.graalvm.python.embedding.VirtualFileSystem;
+import org.graalvm.polyglot.io.IOAccess;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GraalPyResourcesTests {
+	private static Engine newPythonEngine() {
+		return Engine.newBuilder("python").option("engine.WarnInterpreterOnly", "false").build();
+	}
+
+	private static String pythonStringLiteral(String value) {
+		return value.replace("\\", "\\\\").replace("'", "\\'");
+	}
+
+	private static String pythonPathLiteral(Path path) {
+		return pythonStringLiteral(path.toAbsolutePath().toString());
+	}
+
+	private static String runtimeConfiguration(Context.Builder builder) {
+		try (Engine engine = newPythonEngine(); Context context = builder.engine(engine).build()) {
+			return context.eval("python", """
+					import json
+					import sys
+					json.dumps([sys.executable, sys.path, sys.dont_write_bytecode, 'site' in sys.modules])
+					""").asString();
+		}
+	}
+
 	@Test
 	public void sharedEngine() {
 		// simply check if we are able to create a context with a shared engine
 		Engine sharedEngine = Engine.create("python");
-		GraalPyResources.contextBuilder().engine(sharedEngine).build().close();
-		GraalPyResources.contextBuilder().engine(sharedEngine).build().close();
-		GraalPyResources.contextBuilder(Path.of("test")).engine(sharedEngine).build().close();
-		GraalPyResources.contextBuilder(VirtualFileSystem.newBuilder().build()).engine(sharedEngine).build().close();
+		Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create())).engine(sharedEngine).build()
+				.close();
+		Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create())).engine(sharedEngine).build()
+				.close();
+		Context.newBuilder().apply(GraalPyResources.of(Path.of("test"))).engine(sharedEngine).build().close();
+		Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.newBuilder().build())).engine(sharedEngine)
+				.build().close();
 		sharedEngine.close();
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void oldAndNewApiEntryPointsSetSameOptions() throws IOException {
+		try (VirtualFileSystem vfs = VirtualFileSystem.newBuilder().build()) {
+			assertEquals(runtimeConfiguration(GraalPyResources.contextBuilder()),
+					runtimeConfiguration(Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create()))));
+			assertEquals(runtimeConfiguration(GraalPyResources.contextBuilder(vfs)),
+					runtimeConfiguration(Context.newBuilder().apply(GraalPyResources.of(vfs))));
+		}
+		Path resourcesDir = Files.createTempDirectory("graalpy-resources-options");
+		try (VirtualFileSystem vfs = VirtualFileSystem.newBuilder().build()) {
+			GraalPyResources.extractVirtualFileSystemResources(vfs, resourcesDir);
+		}
+		assertEquals(runtimeConfiguration(GraalPyResources.contextBuilder(resourcesDir)),
+				runtimeConfiguration(Context.newBuilder().apply(GraalPyResources.of(resourcesDir))));
+	}
+
+	@Test
+	public void testExtendJavaEmbeddingConfig() {
+		try (Engine engine = newPythonEngine();
+				Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL)
+						.apply(GraalPyResources.of(VirtualFileSystem.create())).engine(engine).build()) {
+			context.getBindings("python").putMember("hostObject", new AtomicInteger(42));
+			assertEquals(42, context.eval("python", "hostObject.get()").asInt());
+		}
+		try (Engine engine = newPythonEngine();
+				Context context = Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create()))
+						.engine(engine).extendHostAccess(HostAccess.ALL,
+								hostAccessBuilder -> hostAccessBuilder.denyAccess(AtomicInteger.class))
+						.build()) {
+			context.getBindings("python").putMember("hostObject", new AtomicInteger(42));
+			assertThrows(PolyglotException.class, () -> context.eval("python", "hostObject.get()"));
+		}
+		try (Engine engine = newPythonEngine();
+				Context context = Context.newBuilder()
+						.extendHostAccess(HostAccess.ALL,
+								hostAccessBuilder -> hostAccessBuilder.denyAccess(AtomicInteger.class))
+						.apply(GraalPyResources.of(VirtualFileSystem.create())).engine(engine).build()) {
+			context.getBindings("python").putMember("hostObject", new AtomicInteger(42));
+			assertThrows(PolyglotException.class, () -> context.eval("python", "hostObject.get()"));
+		}
+	}
+
+	// file known to be in the testing VFS
+	private static String file1Path(String root) {
+		return root + (root.endsWith("\\") ? "\\file1" : "/file1");
+	}
+
+	@Test
+	public void testExtendIOConfig() throws IOException {
+		Path resourcesDir = Files.createTempDirectory("graalpy-resources-test");
+		Path file1 = Path.of(file1Path(resourcesDir.toString()));
+		String defaultFile1;
+		try (VirtualFileSystem vfs = VirtualFileSystem.newBuilder().build()) {
+			GraalPyResources.extractVirtualFileSystemResources(vfs, resourcesDir);
+			defaultFile1 = file1Path(vfs.getMountPoint());
+		}
+		try (Engine engine = newPythonEngine();
+				Context context = Context.newBuilder().apply(GraalPyResources.of(resourcesDir)).engine(engine)
+						.build()) {
+			assertEquals("text1\ntext2\n",
+					context.eval("python", "open('%s').read()".formatted(pythonPathLiteral(file1))).asString());
+		}
+		assertThrows(PolyglotException.class, () -> {
+			try (Engine engine = newPythonEngine();
+					Context context = Context.newBuilder().apply(GraalPyResources.of(resourcesDir)).engine(engine)
+							.extendIO(IOAccess.ALL, ioBuilder -> ioBuilder.allowHostFileAccess(false)).build()) {
+				context.eval("python", "open('%s').read()".formatted(pythonPathLiteral(file1)));
+			}
+		});
+		try (Engine engine = newPythonEngine();
+				Context context = Context.newBuilder()
+						.extendIO(IOAccess.ALL, ioBuilder -> ioBuilder.allowHostFileAccess(false))
+						.apply(GraalPyResources.of(resourcesDir)).engine(engine).build()) {
+			assertEquals("text1\ntext2\n",
+					context.eval("python", "open('%s').read()".formatted(pythonPathLiteral(file1))).asString());
+		}
+		try (Engine engine = newPythonEngine();
+				Context context = Context.newBuilder().allowIO(IOAccess.NONE)
+						.apply(GraalPyResources.of(VirtualFileSystem.create())).engine(engine).build()) {
+			assertEquals("text1\ntext2\n", context
+					.eval("python", "open('%s').read()".formatted(pythonStringLiteral(defaultFile1))).asString());
+		}
 	}
 }

--- a/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/integration/GraalPyResourcesTests.java
+++ b/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/integration/GraalPyResourcesTests.java
@@ -84,12 +84,16 @@ public class GraalPyResourcesTests {
 	public void sharedEngine() {
 		// simply check if we are able to create a context with a shared engine
 		Engine sharedEngine = Engine.create("python");
-		Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create())).engine(sharedEngine).build()
+		Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
+				.engine(sharedEngine).build()
 				.close();
-		Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create())).engine(sharedEngine).build()
+		Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
+				.engine(sharedEngine).build()
 				.close();
-		Context.newBuilder().apply(GraalPyResources.of(Path.of("test"))).engine(sharedEngine).build().close();
-		Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.newBuilder().build())).engine(sharedEngine)
+		Context.newBuilder().apply(GraalPyResources.forExternalDirectory(Path.of("test"))).engine(sharedEngine).build()
+				.close();
+		Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.newBuilder().build()))
+				.engine(sharedEngine)
 				.build().close();
 		sharedEngine.close();
 	}
@@ -99,28 +103,31 @@ public class GraalPyResourcesTests {
 	public void oldAndNewApiEntryPointsSetSameOptions() throws IOException {
 		try (VirtualFileSystem vfs = VirtualFileSystem.newBuilder().build()) {
 			assertEquals(runtimeConfiguration(GraalPyResources.contextBuilder()),
-					runtimeConfiguration(Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create()))));
+					runtimeConfiguration(Context.newBuilder()
+							.apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))));
 			assertEquals(runtimeConfiguration(GraalPyResources.contextBuilder(vfs)),
-					runtimeConfiguration(Context.newBuilder().apply(GraalPyResources.of(vfs))));
+					runtimeConfiguration(Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(vfs))));
 		}
 		Path resourcesDir = Files.createTempDirectory("graalpy-resources-options");
 		try (VirtualFileSystem vfs = VirtualFileSystem.newBuilder().build()) {
 			GraalPyResources.extractVirtualFileSystemResources(vfs, resourcesDir);
 		}
 		assertEquals(runtimeConfiguration(GraalPyResources.contextBuilder(resourcesDir)),
-				runtimeConfiguration(Context.newBuilder().apply(GraalPyResources.of(resourcesDir))));
+				runtimeConfiguration(Context.newBuilder().apply(GraalPyResources.forExternalDirectory(resourcesDir))));
 	}
 
 	@Test
 	public void testExtendJavaEmbeddingConfig() {
 		try (Engine engine = newPythonEngine();
 				Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL)
-						.apply(GraalPyResources.of(VirtualFileSystem.create())).engine(engine).build()) {
+						.apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create())).engine(engine)
+						.build()) {
 			context.getBindings("python").putMember("hostObject", new AtomicInteger(42));
 			assertEquals(42, context.eval("python", "hostObject.get()").asInt());
 		}
 		try (Engine engine = newPythonEngine();
-				Context context = Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create()))
+				Context context = Context.newBuilder()
+						.apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
 						.engine(engine).extendHostAccess(HostAccess.ALL,
 								hostAccessBuilder -> hostAccessBuilder.denyAccess(AtomicInteger.class))
 						.build()) {
@@ -131,7 +138,8 @@ public class GraalPyResourcesTests {
 				Context context = Context.newBuilder()
 						.extendHostAccess(HostAccess.ALL,
 								hostAccessBuilder -> hostAccessBuilder.denyAccess(AtomicInteger.class))
-						.apply(GraalPyResources.of(VirtualFileSystem.create())).engine(engine).build()) {
+						.apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create())).engine(engine)
+						.build()) {
 			context.getBindings("python").putMember("hostObject", new AtomicInteger(42));
 			assertThrows(PolyglotException.class, () -> context.eval("python", "hostObject.get()"));
 		}
@@ -152,14 +160,16 @@ public class GraalPyResourcesTests {
 			defaultFile1 = file1Path(vfs.getMountPoint());
 		}
 		try (Engine engine = newPythonEngine();
-				Context context = Context.newBuilder().apply(GraalPyResources.of(resourcesDir)).engine(engine)
+				Context context = Context.newBuilder().apply(GraalPyResources.forExternalDirectory(resourcesDir))
+						.engine(engine)
 						.build()) {
 			assertEquals("text1\ntext2\n",
 					context.eval("python", "open('%s').read()".formatted(pythonPathLiteral(file1))).asString());
 		}
 		assertThrows(PolyglotException.class, () -> {
 			try (Engine engine = newPythonEngine();
-					Context context = Context.newBuilder().apply(GraalPyResources.of(resourcesDir)).engine(engine)
+					Context context = Context.newBuilder().apply(GraalPyResources.forExternalDirectory(resourcesDir))
+							.engine(engine)
 							.extendIO(IOAccess.ALL, ioBuilder -> ioBuilder.allowHostFileAccess(false)).build()) {
 				context.eval("python", "open('%s').read()".formatted(pythonPathLiteral(file1)));
 			}
@@ -167,13 +177,14 @@ public class GraalPyResourcesTests {
 		try (Engine engine = newPythonEngine();
 				Context context = Context.newBuilder()
 						.extendIO(IOAccess.ALL, ioBuilder -> ioBuilder.allowHostFileAccess(false))
-						.apply(GraalPyResources.of(resourcesDir)).engine(engine).build()) {
+						.apply(GraalPyResources.forExternalDirectory(resourcesDir)).engine(engine).build()) {
 			assertEquals("text1\ntext2\n",
 					context.eval("python", "open('%s').read()".formatted(pythonPathLiteral(file1))).asString());
 		}
 		try (Engine engine = newPythonEngine();
 				Context context = Context.newBuilder().allowIO(IOAccess.NONE)
-						.apply(GraalPyResources.of(VirtualFileSystem.create())).engine(engine).build()) {
+						.apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create())).engine(engine)
+						.build()) {
 			assertEquals("text1\ntext2\n", context
 					.eval("python", "open('%s').read()".formatted(pythonStringLiteral(defaultFile1))).asString());
 		}

--- a/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/integration/VirtualFileSystemIntegrationTest.java
+++ b/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/integration/VirtualFileSystemIntegrationTest.java
@@ -133,9 +133,10 @@ public class VirtualFileSystemIntegrationTest {
 
 	private Context.Builder newContextBuilder(String resourceDirectory) {
 		if (useDefaultResourcesDir(resourceDirectory)) {
-			return GraalPyResources.contextBuilder().engine(engine);
+			return Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create())).engine(engine);
 		}
-		return GraalPyResources.contextBuilder(createVirtualFileSystem(resourceDirectory)).engine(engine);
+		return Context.newBuilder().apply(GraalPyResources.of(createVirtualFileSystem(resourceDirectory)))
+				.engine(engine);
 	}
 
 	private VirtualFileSystem.Builder newVirtualFileSystemBuilder(String resourceDirectory) {
@@ -179,7 +180,7 @@ public class VirtualFileSystemIntegrationTest {
 				unixMountPoint(multiPathUnixMountPoint).//
 				windowsMountPoint(multiPathWinMountPoint).//
 				resourceLoadingClass(VirtualFileSystemIntegrationTest.class).build();
-		try (Context ctx = addTestOptions(GraalPyResources.contextBuilder(vfs)).build()) {
+		try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(vfs))).build()) {
 			ctx.eval(PYTHON, "from os import listdir; listdir('"
 					+ (IS_WINDOWS ? multiPathWinMountPoint.replace("\\", "\\\\") : multiPathUnixMountPoint) + "')");
 		}
@@ -592,7 +593,7 @@ public class VirtualFileSystemIntegrationTest {
 			builder = vfsBuilderFunction.apply(builder);
 		}
 		VirtualFileSystem fs = builder.build();
-		Context.Builder ctxBuilder = addTestOptions(GraalPyResources.contextBuilder(fs));
+		Context.Builder ctxBuilder = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(fs)));
 		if (ctxBuilderFunction != null) {
 			ctxBuilder = ctxBuilderFunction.apply(ctxBuilder);
 		}
@@ -623,7 +624,7 @@ public class VirtualFileSystemIntegrationTest {
 				unixMountPoint(VFS_MOUNT_POINT).//
 				windowsMountPoint(VFS_WIN_MOUNT_POINT).//
 				resourceLoadingClass(VirtualFileSystemIntegrationTest.class).build();
-		try (Context context = addTestOptions(GraalPyResources.contextBuilder(fs)).build()) {
+		try (Context context = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(fs))).build()) {
 			context.eval(PYTHON, patchMountPoint("from os import listdir; listdir('/test_mount_point')"));
 		}
 
@@ -670,7 +671,7 @@ public class VirtualFileSystemIntegrationTest {
 
 		// create context with extracted resource dir and check if we can see the
 		// extracted file
-		try (Context context = addTestOptions(GraalPyResources.contextBuilder(resourcesDir)).build()) {
+		try (Context context = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(resourcesDir))).build()) {
 			context.eval("python", "import os; assert os.path.exists('"
 					+ resourcesDir.resolve("file1").toString().replace("\\", "\\\\") + "')");
 		}
@@ -726,13 +727,13 @@ public class VirtualFileSystemIntegrationTest {
 				unixMountPoint(VFS_UNIX_MOUNT_POINT).//
 				windowsMountPoint(VFS_WIN_MOUNT_POINT).build();
 		assertEquals(VFS_MOUNT_POINT, vfs.getMountPoint());
-		try (Context ctx = addTestOptions(GraalPyResources.contextBuilder(vfs)).build()) {
+		try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(vfs))).build()) {
 			Value paths = ctx.eval("python", getPathsSource);
 			checkPaths(paths.as(List.class), vfs.getMountPoint());
 		}
 		Path resourcesDir = Files.createTempDirectory("python-resources");
 
-		try (Context ctx = addTestOptions(GraalPyResources.contextBuilder(resourcesDir)).build()) {
+		try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(resourcesDir))).build()) {
 			Value paths = ctx.eval("python", getPathsSource);
 			checkPaths(paths.as(List.class), resourcesDir.toString());
 		}
@@ -753,7 +754,7 @@ public class VirtualFileSystemIntegrationTest {
 	@Test
 	public void testAnotherVfs() throws IOException {
 		try (var vfs = VirtualFileSystem.newBuilder().resourceDirectory("GRAALPY-VFS/foo").build()) {
-			try (Context ctx = addTestOptions(GraalPyResources.contextBuilder(vfs)).build()) {
+			try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(vfs))).build()) {
 				eval(ctx, """
 						def test(mount_point):
 						    import os
@@ -774,7 +775,7 @@ public class VirtualFileSystemIntegrationTest {
 	@Test
 	public void testVfsWithoutVenv() throws IOException {
 		try (var vfs = VirtualFileSystem.newBuilder().resourceDirectory("SIMPLE-VFS").build()) {
-			try (Context ctx = addTestOptions(GraalPyResources.contextBuilder(vfs)).build()) {
+			try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(vfs))).build()) {
 				eval(ctx, """
 						def test(mount_point):
 						    import os

--- a/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/integration/VirtualFileSystemIntegrationTest.java
+++ b/org.graalvm.python.embedding/src/test/java/org/graalvm/python/embedding/test/integration/VirtualFileSystemIntegrationTest.java
@@ -133,9 +133,11 @@ public class VirtualFileSystemIntegrationTest {
 
 	private Context.Builder newContextBuilder(String resourceDirectory) {
 		if (useDefaultResourcesDir(resourceDirectory)) {
-			return Context.newBuilder().apply(GraalPyResources.of(VirtualFileSystem.create())).engine(engine);
+			return Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
+					.engine(engine);
 		}
-		return Context.newBuilder().apply(GraalPyResources.of(createVirtualFileSystem(resourceDirectory)))
+		return Context.newBuilder()
+				.apply(GraalPyResources.forVirtualFileSystem(createVirtualFileSystem(resourceDirectory)))
 				.engine(engine);
 	}
 
@@ -180,7 +182,8 @@ public class VirtualFileSystemIntegrationTest {
 				unixMountPoint(multiPathUnixMountPoint).//
 				windowsMountPoint(multiPathWinMountPoint).//
 				resourceLoadingClass(VirtualFileSystemIntegrationTest.class).build();
-		try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(vfs))).build()) {
+		try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(vfs)))
+				.build()) {
 			ctx.eval(PYTHON, "from os import listdir; listdir('"
 					+ (IS_WINDOWS ? multiPathWinMountPoint.replace("\\", "\\\\") : multiPathUnixMountPoint) + "')");
 		}
@@ -593,7 +596,8 @@ public class VirtualFileSystemIntegrationTest {
 			builder = vfsBuilderFunction.apply(builder);
 		}
 		VirtualFileSystem fs = builder.build();
-		Context.Builder ctxBuilder = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(fs)));
+		Context.Builder ctxBuilder = addTestOptions(
+				Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(fs)));
 		if (ctxBuilderFunction != null) {
 			ctxBuilder = ctxBuilderFunction.apply(ctxBuilder);
 		}
@@ -624,7 +628,8 @@ public class VirtualFileSystemIntegrationTest {
 				unixMountPoint(VFS_MOUNT_POINT).//
 				windowsMountPoint(VFS_WIN_MOUNT_POINT).//
 				resourceLoadingClass(VirtualFileSystemIntegrationTest.class).build();
-		try (Context context = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(fs))).build()) {
+		try (Context context = addTestOptions(Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(fs)))
+				.build()) {
 			context.eval(PYTHON, patchMountPoint("from os import listdir; listdir('/test_mount_point')"));
 		}
 
@@ -671,7 +676,8 @@ public class VirtualFileSystemIntegrationTest {
 
 		// create context with extracted resource dir and check if we can see the
 		// extracted file
-		try (Context context = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(resourcesDir))).build()) {
+		try (Context context = addTestOptions(
+				Context.newBuilder().apply(GraalPyResources.forExternalDirectory(resourcesDir))).build()) {
 			context.eval("python", "import os; assert os.path.exists('"
 					+ resourcesDir.resolve("file1").toString().replace("\\", "\\\\") + "')");
 		}
@@ -727,13 +733,15 @@ public class VirtualFileSystemIntegrationTest {
 				unixMountPoint(VFS_UNIX_MOUNT_POINT).//
 				windowsMountPoint(VFS_WIN_MOUNT_POINT).build();
 		assertEquals(VFS_MOUNT_POINT, vfs.getMountPoint());
-		try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(vfs))).build()) {
+		try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(vfs)))
+				.build()) {
 			Value paths = ctx.eval("python", getPathsSource);
 			checkPaths(paths.as(List.class), vfs.getMountPoint());
 		}
 		Path resourcesDir = Files.createTempDirectory("python-resources");
 
-		try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(resourcesDir))).build()) {
+		try (Context ctx = addTestOptions(
+				Context.newBuilder().apply(GraalPyResources.forExternalDirectory(resourcesDir))).build()) {
 			Value paths = ctx.eval("python", getPathsSource);
 			checkPaths(paths.as(List.class), resourcesDir.toString());
 		}
@@ -754,7 +762,8 @@ public class VirtualFileSystemIntegrationTest {
 	@Test
 	public void testAnotherVfs() throws IOException {
 		try (var vfs = VirtualFileSystem.newBuilder().resourceDirectory("GRAALPY-VFS/foo").build()) {
-			try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(vfs))).build()) {
+			try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(vfs)))
+					.build()) {
 				eval(ctx, """
 						def test(mount_point):
 						    import os
@@ -775,7 +784,8 @@ public class VirtualFileSystemIntegrationTest {
 	@Test
 	public void testVfsWithoutVenv() throws IOException {
 		try (var vfs = VirtualFileSystem.newBuilder().resourceDirectory("SIMPLE-VFS").build()) {
-			try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.of(vfs))).build()) {
+			try (Context ctx = addTestOptions(Context.newBuilder().apply(GraalPyResources.forVirtualFileSystem(vfs)))
+					.build()) {
 				eval(ctx, """
 						def test(mount_point):
 						    import os

--- a/org.graalvm.python.gradle.plugin/src/main/java/org/graalvm/python/tasks/AbstractPackagesTask.java
+++ b/org.graalvm.python.gradle.plugin/src/main/java/org/graalvm/python/tasks/AbstractPackagesTask.java
@@ -143,7 +143,7 @@ public abstract class AbstractPackagesTask extends DefaultTask {
 
 	private JavaToolchain getJavaToolchain() {
 		JavaLauncher javaLauncher = getJavaLauncher().get();
-		return JavaToolchain.fromJavaExecutable(javaLauncher.getExecutablePath().getAsFile().toPath(),
+		return JavaToolchain.fromJavaExecutableAndVersion(javaLauncher.getExecutablePath().getAsFile().toPath(),
 				javaLauncher.getMetadata().getLanguageVersion().asInt());
 	}
 

--- a/org.graalvm.python.jbang/catalog/examples/hello.java
+++ b/org.graalvm.python.jbang/catalog/examples/hello.java
@@ -45,13 +45,20 @@
 //PIP termcolor==2.2
 
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.PolyglotAccess;
 import org.graalvm.polyglot.PolyglotException;
+import org.graalvm.polyglot.io.IOAccess;
 import org.graalvm.python.embedding.GraalPyResources;
+import org.graalvm.python.embedding.VirtualFileSystem;
 
 public class hello {
     public static void main(String[] args) {
         System.out.println("Running main method from Java.");
-        try (Context context = GraalPyResources.createContext()) {
+        try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
+                .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
+                .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             switch (args.length) {
                 case 0:
                     context.eval("python", "from termcolor import colored; print(print(colored('hello java', 'red', attrs=['reverse', 'blink'])))");

--- a/org.graalvm.python.jbang/catalog/examples/hello.java
+++ b/org.graalvm.python.jbang/catalog/examples/hello.java
@@ -57,7 +57,7 @@ public class hello {
         System.out.println("Running main method from Java.");
         try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
                 .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                .apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
                 .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             switch (args.length) {
                 case 0:

--- a/org.graalvm.python.jbang/catalog/templates/graalpy-template.java.qute
+++ b/org.graalvm.python.jbang/catalog/templates/graalpy-template.java.qute
@@ -10,16 +10,20 @@
 //PIP termcolor==2.2
 |}
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Context.Builder;
+import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.PolyglotAccess;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.io.IOAccess;
 import org.graalvm.python.embedding.GraalPyResources;
+import org.graalvm.python.embedding.VirtualFileSystem;
 
 public class {baseName} {
     public static void main(String[] args) {
 
-        try (Context context = GraalPyResources.createContext()) {
+        try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
+                .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
+                .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             switch (args.length) {
                 case 0:
                     context.eval("python", "import site; site._script()");

--- a/org.graalvm.python.jbang/catalog/templates/graalpy-template.java.qute
+++ b/org.graalvm.python.jbang/catalog/templates/graalpy-template.java.qute
@@ -22,7 +22,7 @@ public class {baseName} {
 
         try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
                 .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                .apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
                 .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             switch (args.length) {
                 case 0:

--- a/org.graalvm.python.jbang/catalog/templates/graalpy-template_local_repo.java.qute
+++ b/org.graalvm.python.jbang/catalog/templates/graalpy-template_local_repo.java.qute
@@ -13,16 +13,20 @@
 //PIP termcolor==2.2
 |}
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Context.Builder;
+import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.PolyglotAccess;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.io.IOAccess;
 import org.graalvm.python.embedding.GraalPyResources;
+import org.graalvm.python.embedding.VirtualFileSystem;
 
 public class {baseName} {
     public static void main(String[] args) {
 
-        try (Context context = GraalPyResources.createContext()) {
+        try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
+                .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
+                .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             switch (args.length) {
                 case 0:
                     context.eval("python", "import site; site._script()");

--- a/org.graalvm.python.jbang/catalog/templates/graalpy-template_local_repo.java.qute
+++ b/org.graalvm.python.jbang/catalog/templates/graalpy-template_local_repo.java.qute
@@ -25,7 +25,7 @@ public class {baseName} {
 
         try (Context context = Context.newBuilder().allowHostAccess(HostAccess.ALL).allowCreateThread(true)
                 .allowNativeAccess(true).allowPolyglotAccess(PolyglotAccess.ALL)
-                .apply(GraalPyResources.of(VirtualFileSystem.create()))
+                .apply(GraalPyResources.forVirtualFileSystem(VirtualFileSystem.create()))
                 .extendIO(IOAccess.NONE, io -> io.allowHostSocketAccess(true)).build()) {
             switch (args.length) {
                 case 0:

--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,9 @@
         <version>2.46.1</version>
         <configuration>
           <java>
-            <eclipse/>
+            <eclipse>
+              <file>${maven.multiModuleProjectDirectory}/configs/eclipse-java-formatter.xml</file>
+            </eclipse>
             <trimTrailingWhitespace/>
             <removeWildcardImports/>
             <!-- We cannot use the licenseHeader, because the spotless Maven plugin does not expose the yearSeparator property -->


### PR DESCRIPTION
Migrates GraalPyResources to the new Context.Builder#apply extension mechanism. Fixes #42.

The new public API methods in `GraalPyResources` configure only what is strictly necessary for given use-case (VFS/external directory) or options without which the use-case would make little sense (allow IO access for external directory), but everything else is left for the user to configure, which is now possible with the new Context.Builder APIs. For example, previously `GraalPyResources` would proactively allow network access, because otherwise user couldn't allow it (that would override the IO access config), but that's not the case anymore.