### PR TITLE
Use a ClassLoader for locating resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ under the "GraalPy Embedding" section.
 
 ## 25.1.0
 
+* `VirtualFileSystem` can now be configured with a custom `ClassLoader` for
+resource lookup. The existing `resourceLoadingClass(Class<?>)` builder method
+now delegates to the class loader of the supplied class.
+
 * `GraalPyResources` now provides `forVirtualFileSystem(VirtualFileSystem)` and
 `forExternalDirectory(Path)` resource configurations that can be applied to an
 existing `Context.Builder` with `Context.Builder.apply(...)`. The older

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystem.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystem.java
@@ -107,7 +107,7 @@ public final class VirtualFileSystem implements AutoCloseable {
 		private HostIO allowHostIO = HostIO.READ_WRITE;
 		private boolean caseInsensitive = VirtualFileSystemImpl.isWindows();
 
-        private ClassLoader resourceClassLoader;
+		private ClassLoader resourceClassLoader;
 
 		private String resourceDirectory;
 
@@ -244,7 +244,8 @@ public final class VirtualFileSystem implements AutoCloseable {
 		 * cases when for example <code>VirtualFileSystem</code> is on module path and
 		 * the jar containing the resources is on class path.
 		 *
-		 * @param c the class for loading the resources
+		 * @param c
+		 *            the class for loading the resources
 		 * @return the builder
 		 * @since 24.2.0
 		 */
@@ -253,21 +254,22 @@ public final class VirtualFileSystem implements AutoCloseable {
 			return this;
 		}
 
-        /**
-         * By default, virtual filesystem resources are loaded by delegating to
-         * <code>VirtualFileSystem.class.getClassLoader().getResource(name)</code>. Use
-         * <code>resourceClassLoader</code> to determine where to locate resources in
-         * cases when for example <code>VirtualFileSystem</code> is on module path and
-         * the jar containing the resources is on class path.
-         *
-         * @param cl the classloader used to load resources
-         * @return this builder
-         * @since 26.0.0
-         */
-        public Builder resourceClassLoader(ClassLoader cl) {
-            resourceClassLoader = cl;
-            return this;
-        }
+		/**
+		 * By default, virtual filesystem resources are loaded by delegating to
+		 * <code>VirtualFileSystem.class.getClassLoader().getResource(name)</code>. Use
+		 * <code>resourceClassLoader</code> to determine where to locate resources in
+		 * cases when for example <code>VirtualFileSystem</code> is on module path and
+		 * the jar containing the resources is on class path.
+		 *
+		 * @param cl
+		 *            the classloader used to load resources
+		 * @return this builder
+		 * @since 26.0.0
+		 */
+		public Builder resourceClassLoader(ClassLoader cl) {
+			resourceClassLoader = cl;
+			return this;
+		}
 
 		/**
 		 * This filter applied to files in the virtual filesystem treats them as
@@ -308,8 +310,8 @@ public final class VirtualFileSystem implements AutoCloseable {
 						? Path.of(DEFAULT_WINDOWS_MOUNT_POINT)
 						: Path.of(DEFAULT_UNIX_MOUNT_POINT);
 			}
-			return new VirtualFileSystem(extractFilter, mountPoint, allowHostIO, resourceClassLoader,
-					resourceDirectory, caseInsensitive);
+			return new VirtualFileSystem(extractFilter, mountPoint, allowHostIO, resourceClassLoader, resourceDirectory,
+					caseInsensitive);
 		}
 	}
 
@@ -327,7 +329,7 @@ public final class VirtualFileSystem implements AutoCloseable {
 			ClassLoader resourceClassLoader, String resourceDirectory, boolean caseInsensitive) {
 
 		this.impl = new VirtualFileSystemImpl(extractFilter, mountPoint, resourceDirectory, allowHostIO,
-				resourceClassLoader,  caseInsensitive);
+				resourceClassLoader, caseInsensitive);
 		this.delegatingFileSystem = VirtualFileSystemImpl.createDelegatingFileSystem(impl);
 	}
 

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystem.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystem.java
@@ -264,7 +264,7 @@ public final class VirtualFileSystem implements AutoCloseable {
 		 * @param cl
 		 *            the classloader used to load resources
 		 * @return this builder
-		 * @since 26.0.0
+		 * @since 25.1.0
 		 */
 		public Builder resourceClassLoader(ClassLoader cl) {
 			resourceClassLoader = cl;

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystemImpl.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystemImpl.java
@@ -145,12 +145,12 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	 * Maps platform-specific paths to entries.
 	 */
 	private final Map<String, BaseEntry> vfsEntries = new HashMap<>();
-    
-    /**
-     * Classloader used to read resources. By defaut, the classloader of
-     * VirtualFileSystem.class.
-     */
-    private final ClassLoader resourceClassLoader;
+
+	/**
+	 * Classloader used to read resources. By defaut, the classloader of
+	 * VirtualFileSystem.class.
+	 */
+	private final ClassLoader resourceClassLoader;
 
 	static final String PLATFORM_SEPARATOR = Paths.get("").getFileSystem().getSeparator();
 	private static final char RESOURCE_SEPARATOR_CHAR = '/';
@@ -307,11 +307,11 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	 */
 	VirtualFileSystemImpl(Predicate<Path> extractFilter, Path mountPoint, String resourceDirectory, HostIO allowHostIO,
 			ClassLoader resourceClassLoader, boolean caseInsensitive) {
-        if (resourceClassLoader != null) {
-            this.resourceClassLoader = resourceClassLoader;
-        } else {
-            this.resourceClassLoader = VirtualFileSystem.class.getClassLoader();
-        }
+		if (resourceClassLoader != null) {
+			this.resourceClassLoader = resourceClassLoader;
+		} else {
+			this.resourceClassLoader = VirtualFileSystem.class.getClassLoader();
+		}
 		this.caseInsensitive = caseInsensitive;
 		this.mountPoint = mountPoint;
 		this.mountPointLowerCase = mountPoint.toString().toLowerCase(Locale.ROOT);
@@ -319,12 +319,14 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		this.platformVenvPath = resourcePathToPlatformPath(absoluteResourcePath(vfsRoot, VFS_VENV));
 		this.platformSrcPath = resourcePathToPlatformPath(absoluteResourcePath(vfsRoot, VFS_SRC));
 
-        if (LOGGER.isLoggable(Level.FINE)) {
-            var classLoaderLabel = this.resourceClassLoader == VirtualFileSystem.class.getClassLoader() ? "VirtualFileSystem" : "custom";
-            fine("VirtualFilesystem %s, allowHostIO: %s, resourceClassLoader: %s, caseInsensitive: %s, extractOnStartup: %s%s",
-                mountPoint, allowHostIO.toString(), classLoaderLabel, caseInsensitive,
-                extractOnStartup, extractFilter != null ? "" : ", extractFilter: null");
-        }
+		if (LOGGER.isLoggable(Level.FINE)) {
+			var classLoaderLabel = this.resourceClassLoader == VirtualFileSystem.class.getClassLoader()
+					? "VirtualFileSystem"
+					: "custom";
+			fine("VirtualFilesystem %s, allowHostIO: %s, resourceClassLoader: %s, caseInsensitive: %s, extractOnStartup: %s%s",
+					mountPoint, allowHostIO.toString(), classLoaderLabel, caseInsensitive, extractOnStartup,
+					extractFilter != null ? "" : ", extractFilter: null");
+		}
 		this.extractFilter = extractFilter;
 		if (extractFilter != null) {
 			try {
@@ -765,8 +767,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		}
 		ArrayList<URL> installedUrls;
 		try {
-			installedUrls = Collections.list(
-                resourceClassLoader.getResources(resourcePath(vfsRoot, INSTALLED_FILE)));
+			installedUrls = Collections.list(resourceClassLoader.getResources(resourcePath(vfsRoot, INSTALLED_FILE)));
 		} catch (IOException e) {
 			warn("Cannot check compatibility of the merged virtual environments. Cannot read list of packages installed in the virtual environments. IOException: "
 					+ e.getMessage());
@@ -810,8 +811,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		// Check compatibility of GraalPy versions that were used to create the VFSs
 		ArrayList<URL> contentsUrls;
 		try {
-			contentsUrls = Collections.list(
-					resourceClassLoader.getResources(resourcePath(vfsRoot, CONTENTS_FILE)));
+			contentsUrls = Collections.list(resourceClassLoader.getResources(resourcePath(vfsRoot, CONTENTS_FILE)));
 		} catch (IOException e) {
 			warn("Cannot check compatibility of the merged virtual environments. Cannot read GraalPy version of the virtual environments. IOException: "
 					+ e.getMessage());

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystemImpl.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystemImpl.java
@@ -145,12 +145,12 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	 * Maps platform-specific paths to entries.
 	 */
 	private final Map<String, BaseEntry> vfsEntries = new HashMap<>();
-
-	/**
-	 * Class used to read resources with getResource(name). By default
-	 * VirtualFileSystem.class.
-	 */
-	private Class<?> resourceLoadingClass;
+    
+    /**
+     * Classloader used to read resources. By defaut, the classloader of
+     * VirtualFileSystem.class.
+     */
+    private final ClassLoader resourceClassLoader;
 
 	static final String PLATFORM_SEPARATOR = Paths.get("").getFileSystem().getSeparator();
 	private static final char RESOURCE_SEPARATOR_CHAR = '/';
@@ -306,12 +306,12 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	 * argument may be {@code null} causing that no extraction will happen.
 	 */
 	VirtualFileSystemImpl(Predicate<Path> extractFilter, Path mountPoint, String resourceDirectory, HostIO allowHostIO,
-			Class<?> resourceLoadingClass, boolean caseInsensitive) {
-		if (resourceLoadingClass != null) {
-			this.resourceLoadingClass = resourceLoadingClass;
-		} else {
-			this.resourceLoadingClass = VirtualFileSystem.class;
-		}
+			ClassLoader resourceClassLoader, boolean caseInsensitive) {
+        if (resourceClassLoader != null) {
+            this.resourceClassLoader = resourceClassLoader;
+        } else {
+            this.resourceClassLoader = VirtualFileSystem.class.getClassLoader();
+        }
 		this.caseInsensitive = caseInsensitive;
 		this.mountPoint = mountPoint;
 		this.mountPointLowerCase = mountPoint.toString().toLowerCase(Locale.ROOT);
@@ -319,10 +319,12 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		this.platformVenvPath = resourcePathToPlatformPath(absoluteResourcePath(vfsRoot, VFS_VENV));
 		this.platformSrcPath = resourcePathToPlatformPath(absoluteResourcePath(vfsRoot, VFS_SRC));
 
-		fine("VirtualFilesystem %s, allowHostIO: %s, resourceLoadingClass: %s, caseInsensitive: %s, extractOnStartup: %s%s",
-				mountPoint, allowHostIO.toString(), this.resourceLoadingClass.getName(), caseInsensitive,
-				extractOnStartup, extractFilter != null ? "" : ", extractFilter: null");
-
+        if (LOGGER.isLoggable(Level.FINE)) {
+            var classLoaderLabel = this.resourceClassLoader == VirtualFileSystem.class.getClassLoader() ? "VirtualFileSystem" : "custom";
+            fine("VirtualFilesystem %s, allowHostIO: %s, resourceClassLoader: %s, caseInsensitive: %s, extractOnStartup: %s%s",
+                mountPoint, allowHostIO.toString(), classLoaderLabel, caseInsensitive,
+                extractOnStartup, extractFilter != null ? "" : ", extractFilter: null");
+        }
 		this.extractFilter = extractFilter;
 		if (extractFilter != null) {
 			try {
@@ -666,7 +668,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	private List<URL> getFilelistURLs(String filelistPath) {
 		List<URL> filelistUrls;
 		try {
-			filelistUrls = Collections.list(this.resourceLoadingClass.getClassLoader().getResources(filelistPath));
+			filelistUrls = Collections.list(resourceClassLoader.getResources(filelistPath));
 		} catch (IOException e) {
 			throw new IllegalStateException("IO error during reading the VirtualFileSystem metadata", e);
 		}
@@ -764,7 +766,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		ArrayList<URL> installedUrls;
 		try {
 			installedUrls = Collections.list(
-					this.resourceLoadingClass.getClassLoader().getResources(resourcePath(vfsRoot, INSTALLED_FILE)));
+                resourceClassLoader.getResources(resourcePath(vfsRoot, INSTALLED_FILE)));
 		} catch (IOException e) {
 			warn("Cannot check compatibility of the merged virtual environments. Cannot read list of packages installed in the virtual environments. IOException: "
 					+ e.getMessage());
@@ -809,7 +811,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		ArrayList<URL> contentsUrls;
 		try {
 			contentsUrls = Collections.list(
-					this.resourceLoadingClass.getClassLoader().getResources(resourcePath(vfsRoot, CONTENTS_FILE)));
+					resourceClassLoader.getResources(resourcePath(vfsRoot, CONTENTS_FILE)));
 		} catch (IOException e) {
 			warn("Cannot check compatibility of the merged virtual environments. Cannot read GraalPy version of the virtual environments. IOException: "
 					+ e.getMessage());
@@ -849,7 +851,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	}
 
 	private URL getResourceUrl(String path) throws IOException {
-		List<URL> urls = Collections.list(this.resourceLoadingClass.getClassLoader().getResources(path.substring(1)));
+		List<URL> urls = Collections.list(resourceClassLoader.getResources(path.substring(1)));
 		if (vfsRootURL != null) {
 			urls = getURLInRoot(urls);
 		}

--- a/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystemImpl.java
+++ b/org.graalvm.python.embedding/src/main/java/org/graalvm/python/embedding/VirtualFileSystemImpl.java
@@ -147,7 +147,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 	private final Map<String, BaseEntry> vfsEntries = new HashMap<>();
 
 	/**
-	 * Classloader used to read resources. By defaut, the classloader of
+	 * Classloader used to read resources. By default, the classloader of
 	 * VirtualFileSystem.class.
 	 */
 	private final ClassLoader resourceClassLoader;
@@ -745,8 +745,7 @@ final class VirtualFileSystemImpl implements FileSystem, AutoCloseable {
 		// the venv
 		ArrayList<URL> venvUrls;
 		try {
-			venvUrls = Collections
-					.list(this.resourceLoadingClass.getClassLoader().getResources(resourcePath(vfsRoot, VFS_VENV)));
+			venvUrls = Collections.list(resourceClassLoader.getResources(resourcePath(vfsRoot, VFS_VENV)));
 		} catch (IOException e) {
 			warn("Cannot check compatibility of the merged virtual environments. Cannot read list of packages installed in the virtual environments. IOException: "
 					+ e.getMessage());


### PR DESCRIPTION
# Description

Before this change, the VirtualFileSystem was using a `Class` as a beacon to find resources. I suppose that the intent was to use `Class#getResource`, but in practice, it's always `clazz.getClassLoader().getResource()` which is used, which makes it redundant to use a class. This commit refactors the code to allow declaring which _classloader_ to use for loading. This is important because in some cases, we don't necessarily have a `Class` to pass, but we _do_ have a classloader. This should also allow more advanced scenarios with filtering classloaders for example.

Since the `Class` was actually never directly used, but only its classloader, this change should have 0 impact for backwards compatibility.

This replaces #32 and preserves the original authored commits from @melix. The takeover branch also rebases the change onto current `main`, fixes the post-rebase stale field reference, updates the `@since` tag, and adds a `CHANGELOG.md` entry.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `./mvnw -pl org.graalvm.python.embedding spotless:check test`

I also tried a full `./mvnw verify`; it was stopped after several minutes without output in the `python-embedding-tools` Surefire phase after the GraalPy pip install child processes had finished.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
