### PR TITLE
[GR-76450] Add GraalPy JBang launcher recipe

### DIFF
--- a/.github/workflows/tests-release-jbang.yml
+++ b/.github/workflows/tests-release-jbang.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Run JBang integration tests
         run: |
           mvn --batch-mode exec:java@integration-tests \
-              -Dproject.polyglot.version=24.2.2 \
+              -Dproject.polyglot.version=25.0.2 \
               -Dintegration.tests.args="test_jbang_integration.py \
-              --jbang-graalpy-version=24.2.2"
+              --jbang-graalpy-version=25.0.2"

--- a/integration-tests/test_jbang_integration.py
+++ b/integration-tests/test_jbang_integration.py
@@ -166,6 +166,19 @@ class TestJBangIntegration(unittest.TestCase):
                 file_path = os.path.normpath(os.path.join(os.path.dirname(self.catalog_file), file_ref))
                 self.assertTrue(os.path.isfile(file_path), f"The path definied in catalog is not found: {file_path}")
 
+    def test_graalpy_launcher_alias(self):
+        if util.extra_maven_repos:
+            self.skipTest("catalog aliases cannot be patched with extra Maven repositories")
+
+        work_dir = self.tmpdir
+        log = util.Logger()
+
+        command = JBANG_CMD + [f"graalpy@{self.catalog_file}", "-c", "print('hello graalpy launcher')"]
+        out, result = run_cmd(command, log=log, cwd=work_dir)
+
+        self.assertEqual(0, result, f"command: {command}\n{log}")
+        self.assertIn("hello graalpy launcher", out)
+
     def test_graalpy_template(self):
         template_name = "graalpy"
         test_file = "graalpy_test.java"

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -4,6 +4,10 @@
     "hello": {
       "script-ref": "./org.graalvm.python.jbang/catalog/examples/hello.java",
       "description": "Script that says hello from Python started from Java or execute Python expression as parameter."
+    },
+    "graalpy": {
+      "script-ref": "./org.graalvm.python.jbang/catalog/examples/graalpy.java",
+      "description": "Launches GraalPy through the published Maven launcher artifacts."
     }
   },
   "templates": {

--- a/org.graalvm.python.jbang/catalog/examples/graalpy.java
+++ b/org.graalvm.python.jbang/catalog/examples/graalpy.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 17+
+//DEPS org.graalvm.python:python-launcher:${env.GRAALPY_VERSION:25.0.2}
+//DEPS org.graalvm.python:python-language:${env.GRAALPY_VERSION:25.0.2}
+//DEPS org.graalvm.python:python-resources:${env.GRAALPY_VERSION:25.0.2}
+//DEPS org.graalvm.truffle:truffle-runtime:${env.GRAALPY_VERSION:25.0.2}
+
+import com.oracle.graal.python.shell.GraalPythonMain;
+
+public class graalpy {
+    public static void main(String[] args) {
+        GraalPythonMain.main(args);
+    }
+}


### PR DESCRIPTION
Adds a `graalpy` alias to the JBang catalog in `graalpy-extensions` so the catalog can launch GraalPy through the published Maven launcher artifacts.

Smoke test:

```bash
GRAALPY_VERSION=25.0.2 jbang --offline graalpy@/home/tim/dev/graalpy-extensions/jbang-catalog.json -c 'print(50)'
```