### PR TITLE
Fix GraalPy pip proxy host formatting

### DIFF
--- a/org.graalvm.python.embedding.tools/src/main/java/org/graalvm/python/embedding/tools/exec/GraalPyRunner.java
+++ b/org.graalvm.python.embedding.tools/src/main/java/org/graalvm/python/embedding/tools/exec/GraalPyRunner.java
@@ -56,6 +56,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public final class GraalPyRunner {
 
@@ -130,18 +131,30 @@ public final class GraalPyRunner {
 	}
 
 	private static void addProxy(ArrayList<String> args) {
-		if (System.getenv("http_proxy") == null && System.getenv("https_proxy") == null) {
-			ProxySelector proxySelector = ProxySelector.getDefault();
+		addProxy(args, System.getenv(), ProxySelector.getDefault());
+	}
+
+	static void addProxy(ArrayList<String> args, Map<String, String> env, ProxySelector proxySelector) {
+		if (env.keySet().stream().noneMatch(k -> k.equalsIgnoreCase("http_proxy") || k.equalsIgnoreCase("https_proxy"))
+				&& proxySelector != null) {
 			List<Proxy> proxies = proxySelector.select(URI.create("https://pypi.org"));
 			for (Proxy proxy : proxies) {
 				if (proxy.type() == Proxy.Type.HTTP && proxy.address() instanceof InetSocketAddress addr) {
-					String proxyAddr = "http://" + addr.getHostName() + ":" + addr.getPort();
 					args.add("--proxy");
-					args.add(proxyAddr);
+					args.add(formatProxyAddress(addr));
 					return;
 				}
 			}
 		}
+	}
+
+	static String formatProxyAddress(InetSocketAddress addr) {
+		String host = addr.getHostString();
+		// IPv6 literals in URI authorities must be enclosed in square brackets.
+		if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
+			host = "[" + host + "]";
+		}
+		return "http://" + host + ":" + addr.getPort();
 	}
 
 	private static void runProcess(ProcessBuilder pb, BuildToolLog log) throws IOException, InterruptedException {

--- a/org.graalvm.python.embedding.tools/src/test/java/org/graalvm/python/embedding/tools/exec/GraalPyRunnerTest.java
+++ b/org.graalvm.python.embedding.tools/src/test/java/org/graalvm/python/embedding/tools/exec/GraalPyRunnerTest.java
@@ -43,9 +43,19 @@ package org.graalvm.python.embedding.tools.exec;
 import org.graalvm.python.embedding.tools.JavaToolchain;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GraalPyRunnerTest {
 
@@ -62,5 +72,42 @@ public class GraalPyRunnerTest {
 		JavaToolchain javaToolchain = JavaToolchain.fromJavaExecutableAndVersion(
 				Path.of("custom-java-home", "bin", "java"), 21);
 		assertArrayEquals(new String[0], GraalPyRunner.getExtraJavaOptions(javaToolchain));
+	}
+
+	@Test
+	public void addsSystemProxyWithoutUnresolvedAddressMarker() {
+		var args = new ArrayList<String>();
+		var address = InetSocketAddress.createUnresolved("127.0.0.1", 7897);
+		GraalPyRunner.addProxy(args, Map.of(), proxySelector(new Proxy(Proxy.Type.HTTP, address)));
+		assertEquals(List.of("--proxy", "http://127.0.0.1:7897"), args);
+	}
+
+	@Test
+	public void formatsIpv6ProxyHost() {
+		var address = InetSocketAddress.createUnresolved("::1", 7897);
+		assertEquals("http://[::1]:7897", GraalPyRunner.formatProxyAddress(address));
+	}
+
+	@Test
+	public void skipsSystemProxyWhenProxyEnvironmentIsConfigured() {
+		var args = new ArrayList<String>();
+		var address = InetSocketAddress.createUnresolved("system-proxy.example.com", 7897);
+		GraalPyRunner.addProxy(args, Map.of("HTTPS_PROXY", "http://env-proxy.example.com:7897"),
+				proxySelector(new Proxy(Proxy.Type.HTTP, address)));
+		assertEquals(List.of(), args);
+	}
+
+	private static ProxySelector proxySelector(Proxy... proxies) {
+		return new ProxySelector() {
+			@Override
+			public List<Proxy> select(URI uri) {
+				assertEquals(URI.create("https://pypi.org"), uri);
+				return List.of(proxies);
+			}
+
+			@Override
+			public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+			}
+		};
 	}
 }


### PR DESCRIPTION
# Description

Fix GraalPy pip proxy formatting so system proxy addresses selected by the JVM are passed to pip using the configured host string instead of an address form that can expose unresolved socket state. The proxy env-var check now honors case-insensitive `http_proxy` / `https_proxy` variants, and IPv6 proxy literals are bracketed for valid URI authority syntax.

Related to https://github.com/graalvm/graal-languages-demos/issues/75

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `./mvnw -pl org.graalvm.python.embedding.tools spotless:check`
- [x] `env JAVA_HOME=/home/steve/.sdkman/candidates/java/21.0.2-open PATH=/home/steve/.sdkman/candidates/java/21.0.2-open/bin:$PATH ./mvnw -pl org.graalvm.python.embedding.tools spotbugs:check`
- [x] `./mvnw -pl org.graalvm.python.embedding.tools -Dtest=GraalPyRunnerTest test`
- [x] `git diff --check`
- [x] pre-commit hooks, including Maven validate and `spotless:apply`

**Test Configuration**:
* JDK 25.0.3 GraalVM for the focused unit test
* JDK 21.0.2 OpenJDK for SpotBugs, because SpotBugs 4.9.3.0 cannot scan JDK 25 runtime classes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules